### PR TITLE
fix: 대시보드 고객 모달 배정 버튼 노출 및 배정 조직도 정책 통일 (#729)

### DIFF
--- a/src/components/customers/AssignCustomersModal.tsx
+++ b/src/components/customers/AssignCustomersModal.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import BaseModal from "@/components/common/BaseModal";
-import { useMe } from "@/hooks/useMe";
-import { useMembersTree, useTeams } from "@/hooks/useMembersTree";
+import { useMyMember } from "@/hooks/useMyMember";
+import { useMembersTreeWithoutParent, useTeams } from "@/hooks/useMembersTree";
 import { MemberTreeNode } from "@/types/membersTree";
 import { TeamMember } from "@/types/teams";
 import { flattenTeamData } from "@/hooks/useTeamTree";
@@ -58,6 +58,36 @@ function transformMembers(
       isExpanded: true,
     };
   });
+}
+
+/**
+ * 특정 멤버를 트리에서 제거하되, 하위 멤버는 상위 레벨로 승격해 보존한다.
+ * (self 숨김 요구사항 대응)
+ */
+function stripMemberFromTree(
+  nodes: MemberTreeNode[] | undefined,
+  targetMemberId: number | null
+): MemberTreeNode[] {
+  if (!nodes?.length) return [];
+  if (targetMemberId == null) return nodes;
+
+  const result: MemberTreeNode[] = [];
+
+  nodes.forEach((node) => {
+    const filteredDescendants = stripMemberFromTree(node.descendants, targetMemberId);
+
+    if (node.id === targetMemberId) {
+      result.push(...filteredDescendants);
+      return;
+    }
+
+    result.push({
+      ...node,
+      descendants: filteredDescendants,
+    });
+  });
+
+  return result;
 }
 
 // 매칭되는 노드와 그 자손들의 ID를 수집
@@ -258,9 +288,9 @@ export default function AssignCustomersModal(props: AssignCustomersModalProps) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [targetId, setTargetId] = useState<number | null>(null);
-  const { user } = useMe();
+  const { member: myMember } = useMyMember(projectId);
 
-  const { data: treeData, isLoading: treeLoading } = useMembersTree(projectId, {
+  const { data: treeData, isLoading: treeLoading } = useMembersTreeWithoutParent(projectId, {
     enabled: open && Boolean(projectId),
   });
   const { data: teamsData } = useTeams(projectId, {
@@ -283,9 +313,14 @@ export default function AssignCustomersModal(props: AssignCustomersModalProps) {
     return map;
   }, [teamsData]);
 
+  const visibleTreeData = useMemo(
+    () => stripMemberFromTree(treeData, myMember?.id ?? null),
+    [treeData, myMember?.id]
+  );
+
   const teamMembers = useMemo(
-    () => transformMembers(treeData, teamNameByLeader),
-    [treeData, teamNameByLeader]
+    () => transformMembers(visibleTreeData, teamNameByLeader),
+    [visibleTreeData, teamNameByLeader]
   );
 
   const flattenedMembers = useMemo(() => flattenTeamData(teamMembers), [teamMembers]);

--- a/src/components/customers/AssignedCustomersTable.tsx
+++ b/src/components/customers/AssignedCustomersTable.tsx
@@ -8,7 +8,6 @@ import { ko } from "date-fns/locale";
 import Panel from "@/components/common/Panel";
 import { useRouter } from "next/navigation";
 import { useSelectedProjectId } from "@/hooks/useSelectedProjectId";
-import { useMyMember } from "@/hooks/useMyMember";
 import { CustomersService } from "@/services/customers";
 import type {
   RecentlyAssignedCustomer,
@@ -37,9 +36,6 @@ export default function AssignedCustomersTable() {
   const [assignFromDetailId, setAssignFromDetailId] = useState<number | null>(null);
 
   const queryClient = useQueryClient();
-  const { role } = useMyMember(projectId);
-  const canAssignCustomer =
-    role === "admin" || role === "subAdmin" || role === "leader";
 
   useEffect(() => {
     setPage(1);
@@ -262,11 +258,7 @@ export default function AssignedCustomersTable() {
         onClose={() => setSelectedCustomerId(null)}
         customerId={selectedCustomerId}
         onCustomerUpdated={handleCustomerUpdated}
-        onAssignClick={
-          canAssignCustomer && selectedCustomerId != null
-            ? handleDetailAssignClick
-            : undefined
-        }
+        onAssignClick={selectedCustomerId != null ? handleDetailAssignClick : undefined}
       />
       {projectId &&
         isAssignOpen &&

--- a/src/hooks/useMembersTree.ts
+++ b/src/hooks/useMembersTree.ts
@@ -22,11 +22,17 @@ export function useMembersTree(
   });
 }
 
-export function useMembersTreeWithoutParent(projectId?: string | number | null) {
+export function useMembersTreeWithoutParent(
+  projectId?: string | number | null,
+  options?: { enabled?: boolean }
+) {
   return useQuery<MemberTreeNode[]>({
     queryKey: treeWithoutParentQueryKey(projectId ?? null),
     queryFn: () => MembersTreeService.fetchRootWithoutParent(projectId as string | number),
-    enabled: Boolean(projectId),
+    enabled:
+      options?.enabled !== undefined
+        ? options.enabled
+        : Boolean(projectId),
   });
 }
 


### PR DESCRIPTION
- 대시보드 새로배정된고객: 상세 모달에 onAssignClick 항상 전달, 버튼 노출은 모달 내부(admin/subAdmin/leader)에서만 판단
- AssignCustomersModal 조직도 API를 /v1/members-tree/tree/without-parent 로 변경 (팀장 상위 멤버 미노출)
- 배정 대상 목록에서 현재 사용자(self) 제거 (stripMemberFromTree)
- useMembersTreeWithoutParent에 enabled 옵션 추가해 배정 모달 오픈 시에만 조직도 조회