### PR TITLE
fix: 회원가입·멤버초대 에러 피드백 분기 보강

### DIFF
--- a/src/components/settings/CommonSenderNumberModal.tsx
+++ b/src/components/settings/CommonSenderNumberModal.tsx
@@ -165,25 +165,10 @@ export default function CommonSenderNumberModal({
     } catch (error: any) {
       console.error("발신번호 등록 실패:", error);
       
-      // 서버에서 반환한 에러 메시지 추출
-      let errorMessage = "발신번호 등록에 실패했습니다.";
-      const rejectionReason = error?.data?.rejectionReason || error?.data?.data?.rejectionReason;
-      
-      if (rejectionReason) {
-        // 반려 사유가 있는 경우 QA 요구사항 형식으로 표시
-        errorMessage = `발신 번호 등록이 반려되었습니다.\n\n사유: ${rejectionReason}\n\n확인 후 다시 등록을 신청해 주세요.`;
-      } else if (error?.data?.message) {
-        errorMessage = error.data.message;
-      } else if (error?.data?.error) {
-        errorMessage = error.data.error;
-      } else if (error?.message) {
-        errorMessage = error.message;
-      }
-      
       showErrorModal({
         type: "error",
         headline: "발신번호 등록에 실패했습니다",
-        description: errorMessage,
+        description: "잠시 후 다시 시도해주세요.",
         hideCancel: true,
       });
     } finally {

--- a/src/components/settings/InvitedMemberSettings.tsx
+++ b/src/components/settings/InvitedMemberSettings.tsx
@@ -334,14 +334,19 @@ export default function InvitedMemberSettings() {
         return;
       }
       
-      // 영어 에러 메시지를 한글로 변환
-      if (errorMessage.includes("Invitation already exists")) {
+      if (
+        errorCode === "INVITATION_ALREADY_EXISTS" ||
+        errorMessage.includes("Invitation already exists")
+      ) {
         showErrorModal({
           type: "error",
           headline: "이미 초대중인 이메일입니다.",
           hideCancel: true,
         });
-      } else if (errorMessage.includes("already a member")) {
+      } else if (
+        errorCode === "ALREADY_PROJECT_MEMBER" ||
+        errorMessage.includes("already a member")
+      ) {
         showErrorModal({
           type: "error",
           headline: "이미 등록된 멤버입니다.",

--- a/src/components/settings/MemberSettings.tsx
+++ b/src/components/settings/MemberSettings.tsx
@@ -377,14 +377,19 @@ export default function MemberSettings() {
         return;
       }
 
-      // 영어 에러 메시지를 한글로 변환
-      if (errorMessage.includes("Invitation already exists")) {
+      if (
+        errorCode === "INVITATION_ALREADY_EXISTS" ||
+        errorMessage.includes("Invitation already exists")
+      ) {
         showErrorModal({
           type: "error",
           headline: "이미 초대중인 이메일입니다.",
           hideCancel: true,
         });
-      } else if (errorMessage.includes("already a member")) {
+      } else if (
+        errorCode === "ALREADY_PROJECT_MEMBER" ||
+        errorMessage.includes("already a member")
+      ) {
         showErrorModal({
           type: "error",
           headline: "이미 등록된 멤버입니다.",

--- a/src/components/signup/AccountStep.tsx
+++ b/src/components/signup/AccountStep.tsx
@@ -12,6 +12,7 @@ import DataCollectionModal from "@/components/signup/DataCollectionModal";
 import MarketingConsentModal from "@/components/signup/MarketingConsentModal";
 import { savePendingSignupState } from "@/lib/signup";
 import { LANDING_URLS } from "@/lib/constants";
+import { showErrorModal } from "@/providers/ErrorFeedbackModalProvider";
 
 type AccountStepProps = {
   onSuccess: (params: { email: string; password: string; tokens?: SignupTokens; agreeMarketing: boolean }) => void;
@@ -136,7 +137,12 @@ export function AccountStep({ onSuccess, invitationToken, inviteEmail }: Account
           }
         } catch (err) {
           console.error("[AccountStep] 회원가입 실패:", err);
-          setInvalid(true);
+          showErrorModal({
+            title: "오류 발생",
+            headline: "처리에 실패했습니다. 잠시 후 다시 시도해주세요.",
+            confirmText: "확인",
+            hideCancel: true,
+          });
         } finally {
           setIsSubmitting(false);
         }


### PR DESCRIPTION
회원가입 400 예외와 멤버 초대 충돌 코드(ALREADY_PROJECT_MEMBER, INVITATION_ALREADY_EXISTS)에 대해 사용자 친화 모달을 명시적으로 처리하고, 발신번호 등록에서 서버 에러 메시지 직접 노출을 일반 문구로 교체해 에러 노출 정책을 일관화합니다.

Made-with: Cursor