### PR TITLE
feat: 고객 성별 필드, 회생파산 고객연동 모달 개편, 문자발송 API 연동

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -876,6 +876,106 @@ svg path:focus {
   animation: analysis-dot 1.2s ease-in-out infinite;
 }
 
+@keyframes analyze-border-rotate {
+  from {
+    transform: translate(-50%, -50%) rotate(0turn);
+  }
+  to {
+    transform: translate(-50%, -50%) rotate(1turn);
+  }
+}
+
+@keyframes analyze-sparkle-start-color {
+  0%,
+  100% {
+    stop-color: #00e272;
+  }
+  50% {
+    stop-color: #3f93ff;
+  }
+}
+
+@keyframes analyze-sparkle-end-color {
+  0%,
+  100% {
+    stop-color: #a9ffd4;
+  }
+  50% {
+    stop-color: #9bc8ff;
+  }
+}
+
+.analyze-button {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  border: 0;
+  border-radius: 5px;
+  background: linear-gradient(135deg, #a1ff8b 0%, #3f93ff 96.83%);
+  filter: drop-shadow(2px 2px 5px #d6fae8);
+}
+
+.analyze-button::before {
+  position: absolute;
+  z-index: 0;
+  top: 50%;
+  left: 50%;
+  width: 150%;
+  aspect-ratio: 1;
+  background: conic-gradient(
+    from 0deg,
+    #a1ff8b 0%,
+    #00e272 24%,
+    #3f93ff 68%,
+    #a1ff8b 100%
+  );
+  content: "";
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  transition: opacity 180ms ease;
+  will-change: transform;
+}
+
+.analyze-button::after {
+  position: absolute;
+  z-index: 0;
+  inset: 2px;
+  border-radius: 3px;
+  background: #ffffff;
+  content: "";
+  pointer-events: none;
+}
+
+.analyze-button:not(:disabled):hover::before {
+  opacity: 1;
+  animation: analyze-border-rotate 1.6s linear infinite;
+}
+
+.analyze-button:not(:disabled):hover .analyze-sparkle-start {
+  animation: analyze-sparkle-start-color 1.6s ease-in-out infinite;
+}
+
+.analyze-button:not(:disabled):hover .analyze-sparkle-end {
+  animation: analyze-sparkle-end-color 1.6s ease-in-out infinite;
+}
+
+.analyze-button:focus-visible {
+  outline: 2px solid #3f93ff;
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .analyze-button:not(:disabled):hover::before {
+    animation: none;
+  }
+
+  .analyze-button:not(:disabled):hover .analyze-sparkle-start,
+  .analyze-button:not(:disabled):hover .analyze-sparkle-end {
+    animation: none;
+  }
+}
+
 /* AI Markdown response styles */
 .ai-markdown {
   word-break: break-word;

--- a/src/components/customers/CustomerCreateModal.tsx
+++ b/src/components/customers/CustomerCreateModal.tsx
@@ -11,6 +11,13 @@ import type { CreateCustomerMessengerInfo } from "@/types/customers";
 import { showConfirmModal } from "@/lib/confirmModalEvents";
 import { showErrorModal } from "@/providers/ErrorFeedbackModalProvider";
 import { format } from "date-fns";
+import { PillSelect } from "@/components/debt-relief/form/PillSelect";
+import type { PillOption } from "@/types/debtRelief";
+
+const GENDER_OPTIONS: PillOption<"male" | "female">[] = [
+  { value: "male", label: "남" },
+  { value: "female", label: "여" },
+];
 
 type Props = {
   open: boolean;
@@ -57,6 +64,7 @@ export default function CustomerCreateModal({
   const [contact2Type, setContact2Type] = useState("집");
   const [contact2, setContact2] = useState("");
   const [birthDate, setBirthDate] = useState<Date | null>(null);
+  const [gender, setGender] = useState<"male" | "female" | "">("");
   const [ageRange, setAgeRange] = useState("");
   const [job, setJob] = useState("");
 
@@ -115,6 +123,7 @@ export default function CustomerCreateModal({
     setContact2Type("집");
     setContact2("");
     setBirthDate(null);
+    setGender("");
     setAgeRange("");
     setJob("");
     setMessengerAccounts([]);
@@ -147,6 +156,7 @@ export default function CustomerCreateModal({
         contact2: contact2.trim() || undefined,
         // 생년월일을 YYYY-MM-DD 형식으로 전송
         birth: birthDate ? format(birthDate, "yyyy-MM-dd") : undefined,
+        gender: gender || undefined,
         ageRange: ageRange || undefined,
         job: job || undefined,
         messengerInfo: messengerInfo.length > 0 ? messengerInfo : undefined,
@@ -453,6 +463,20 @@ export default function CustomerCreateModal({
                     placeholder="생년월일을 입력하세요"
                     dateFormat="yyyy-MM-dd"
                     className="!h-[33px] !rounded-[5px] border-neutral-30 dark:border-neutral-30 bg-card dark:bg-neutral-10 text-ink dark:text-ink"
+                  />
+                </div>
+
+                {/* 성별 */}
+                <div>
+                  <label className="block text-[14px] leading-[17px] text-[#808080] dark:text-neutral-60 mb-2 tracking-[0.2px]">
+                    성별
+                  </label>
+                  <PillSelect
+                    options={GENDER_OPTIONS}
+                    value={gender || null}
+                    onChange={(value) =>
+                      setGender((prev) => (prev === value ? "" : value))
+                    }
                   />
                 </div>
 

--- a/src/components/customers/detail/BasicTab.tsx
+++ b/src/components/customers/detail/BasicTab.tsx
@@ -9,6 +9,13 @@ import { CustomerFormState, CustomerValidation } from "./useCustomerDetail";
 import { ContactType, CustomerLinkedAnalysis } from "@/types/customers";
 import { formatPhoneNumber, getPhoneFormatCursorPosition } from "@/utils/format";
 import { format, isValid, parse } from "date-fns";
+import { PillSelect } from "@/components/debt-relief/form/PillSelect";
+import type { PillOption } from "@/types/debtRelief";
+
+const GENDER_OPTIONS: PillOption<"male" | "female">[] = [
+  { value: "male", label: "남" },
+  { value: "female", label: "여" },
+];
 
 type Props = {
   customerId: number;
@@ -226,19 +233,23 @@ export default function BasicTab({
         </div>
       </div>
 
-      {/* Job */}
+      {/* Gender */}
       <div>
         <div className="mb-1">
-          <span className="text-[14px] text-[#6B7280] dark:text-neutral-60 font-medium">직업</span>
+          <span className="text-[14px] text-[#808080] dark:text-neutral-60 font-medium tracking-[0.2px]">
+            성별
+          </span>
         </div>
-        <div>
-          <input
-            value={form.job}
-            onChange={(e) => setForm((prev) => ({ ...prev, job: e.target.value }))}
-            className="w-full h-[34px] rounded-[5px] border border-[#E5E7EB] dark:border-[#444444] px-3 font-medium text-[14px]"
-            placeholder="직업을 입력하세요."
-          />
-        </div>
+        <PillSelect
+          options={GENDER_OPTIONS}
+          value={form.gender === "male" || form.gender === "female" ? form.gender : null}
+          onChange={(value) =>
+            setForm((prev) => ({
+              ...prev,
+              gender: prev.gender === value ? "" : value,
+            }))
+          }
+        />
       </div>
 
       {/* Age Range */}
@@ -254,6 +265,21 @@ export default function BasicTab({
             }
             className="w-full h-[34px] rounded-[5px] border border-[#E5E7EB] dark:border-[#444444] px-3 font-medium text-[14px]"
             placeholder="연령대를 입력하세요."
+          />
+        </div>
+      </div>
+
+      {/* Job */}
+      <div>
+        <div className="mb-1">
+          <span className="text-[14px] text-[#6B7280] dark:text-neutral-60 font-medium">직업</span>
+        </div>
+        <div>
+          <input
+            value={form.job}
+            onChange={(e) => setForm((prev) => ({ ...prev, job: e.target.value }))}
+            className="w-full h-[34px] rounded-[5px] border border-[#E5E7EB] dark:border-[#444444] px-3 font-medium text-[14px]"
+            placeholder="직업을 입력하세요."
           />
         </div>
       </div>

--- a/src/components/customers/detail/types.ts
+++ b/src/components/customers/detail/types.ts
@@ -12,6 +12,7 @@ export type CustomerFormState = {
   contact2Type: ContactType | null;
   birth: string;
   ageRange: string;
+  gender: string;
   job: string;
   applicationRoute: string;
   site: string;
@@ -43,6 +44,7 @@ export const INITIAL_FORM_STATE: CustomerFormState = {
   contact2Type: null,
   birth: "",
   ageRange: "",
+  gender: "",
   job: "",
   applicationRoute: "",
   site: "",
@@ -76,6 +78,7 @@ export const FORM_TO_API_FIELD_MAP: Record<
   contact2Type: "contact2Type",
   birth: "birth",
   ageRange: "ageRange",
+  gender: "gender",
   job: "job",
   applicationRoute: "applicationRoute",
   site: "site",

--- a/src/components/customers/detail/useCustomerForm.ts
+++ b/src/components/customers/detail/useCustomerForm.ts
@@ -50,6 +50,7 @@ export function useCustomerForm(): UseCustomerFormReturn {
       contact2Type: detail.contact2Type ?? null,
       birth,
       ageRange: detail.ageRange ?? "",
+      gender: detail.gender === "male" || detail.gender === "female" ? detail.gender : "",
       job: detail.job ?? "",
       applicationRoute: detail.applicationRoute ?? "",
       site: detail.site ?? "",

--- a/src/components/debt-relief/DebtReliefHubContent.tsx
+++ b/src/components/debt-relief/DebtReliefHubContent.tsx
@@ -12,7 +12,6 @@ import DiagnosisTable from "@/components/debt-relief/hub/DiagnosisTable";
 import DiagnosisMobileCardList from "@/components/debt-relief/hub/DiagnosisMobileCardList";
 import AnalysisShareModal from "@/components/debt-relief/hub/AnalysisShareModal";
 import Pagination from "@/components/common/Pagination";
-import Checkbox from "@/components/common/Checkbox";
 import { showConfirmModal } from "@/lib/confirmModalEvents";
 import { showErrorModal } from "@/lib/errorModalEvents";
 import { DebtReliefService } from "@/services/debtRelief";
@@ -222,31 +221,6 @@ export default function DebtReliefHubContent() {
             />
           </div>
         </div>
-
-        {hasSelection && (
-          <div className="flex items-center flex-wrap gap-3 md:gap-4 mb-4">
-            <div className="flex items-center gap-2 cursor-pointer" onClick={toggleSelectAll}>
-              <div onClick={(e) => e.stopPropagation()}>
-                <Checkbox
-                  checked={allSelectedOnPage}
-                  onChange={toggleSelectAll}
-                  ariaLabel="전체 선택"
-                  size={24}
-                />
-              </div>
-              <span className="text-[14px] font-medium text-foreground whitespace-nowrap">
-                전체 {selectedIds.size}건 선택됨
-              </span>
-            </div>
-            <button
-              type="button"
-              onClick={clearSelection}
-              className="cursor-pointer text-[13px] text-neutral-50 underline hover:text-neutral-70 transition-colors"
-            >
-              선택해제
-            </button>
-          </div>
-        )}
 
         {/* 데스크톱: 표 (가로 스크롤). 모바일: 카드 리스트 — Figma 모바일 목업 기준 별도 컴포넌트 */}
         <div className="hidden md:block">

--- a/src/components/debt-relief/form/DiagnosisFormContent.tsx
+++ b/src/components/debt-relief/form/DiagnosisFormContent.tsx
@@ -139,6 +139,19 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
   const handleAnalyze = async () => {
     if (analyzing || !canAnalyze) return;
 
+    if (!Number.isFinite(derived.totalDebtManwon) || derived.totalDebtManwon <= 0) {
+      showErrorModal({
+        type: "info",
+        title: "알림",
+        headline: "채무 현황을 파악해주세요.",
+        description: "분석을 진행하려면 채무 종류와 금액을 입력해주세요.",
+        confirmText: "채무 현황 입력",
+        hideCancel: true,
+        onConfirm: () => goToStep(2),
+      });
+      return;
+    }
+
     const missingFields = getMissingRequiredFieldLabels(form);
     if (missingFields.length > 0) {
       showErrorModal({

--- a/src/components/debt-relief/form/FormSidebar.tsx
+++ b/src/components/debt-relief/form/FormSidebar.tsx
@@ -4,6 +4,31 @@ import FormCustomerSummary from "./FormCustomerSummary";
 import FormFinancialSummary from "./FormFinancialSummary";
 import FormStepChecklist from "./FormStepChecklist";
 
+function AnalyzeSparkleIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+      <path
+        d="M9.38432 15.6434L9.37588 15.6447L9.32595 15.6672L9.31188 15.6697L9.30204 15.6672L9.2521 15.6441C9.2446 15.6423 9.23897 15.6436 9.23522 15.6479L9.23241 15.6543L9.22045 15.929L9.22397 15.9418L9.231 15.9502L9.30414 15.9977L9.31469 16.0002L9.32313 15.9977L9.39627 15.9502L9.40471 15.9399L9.40753 15.929L9.39557 15.655C9.3937 15.6481 9.38995 15.6443 9.38432 15.6434ZM9.56998 15.5709L9.56014 15.5722L9.43074 15.6319L9.4237 15.6383L9.42159 15.6453L9.43425 15.9213L9.43777 15.929L9.44339 15.9341L9.58475 15.9932C9.59366 15.9953 9.60046 15.9936 9.60515 15.9881L9.60796 15.9791L9.58405 15.585C9.58171 15.5769 9.57702 15.5722 9.56998 15.5709ZM9.06714 15.5722C9.06404 15.5705 9.06034 15.5699 9.0568 15.5706C9.05326 15.5713 9.05016 15.5733 9.04815 15.576L9.04393 15.585L9.02002 15.9791C9.02049 15.9868 9.02447 15.9919 9.03198 15.9945L9.04252 15.9932L9.18388 15.9335L9.19092 15.9284L9.19303 15.9213L9.20569 15.6453L9.20358 15.6376L9.19654 15.6312L9.06714 15.5722Z"
+        fill="url(#analyzeSparkleSmall)"
+      />
+      <path
+        d="M6.93167 4.21289C7.35223 3.08976 9.05277 3.05574 9.55139 4.11085L9.59359 4.21353L10.1611 5.72816C10.2912 6.07551 10.5014 6.39338 10.7775 6.66031C11.0536 6.92724 11.3893 7.13702 11.7618 7.27551L11.9144 7.3275L13.5742 7.84478C14.8049 8.22857 14.8422 9.78042 13.6867 10.2354L13.5742 10.274L11.9144 10.7919C11.5336 10.9105 11.1852 11.1023 10.8926 11.3543C10.5999 11.6062 10.3699 11.9126 10.2181 12.2526L10.1611 12.3912L9.59429 13.9065C9.17373 15.0296 7.4732 15.0636 6.97528 14.0092L6.93167 13.9065L6.36483 12.3919C6.23485 12.0444 6.0247 11.7264 5.74857 11.4594C5.47244 11.1923 5.13675 10.9824 4.76416 10.8439L4.61225 10.7919L2.95251 10.2746C1.72106 9.8908 1.68379 8.33896 2.83998 7.88457L2.95251 7.84478L4.61225 7.3275C4.99289 7.2088 5.34121 7.01699 5.63371 6.76501C5.92622 6.51303 6.1561 6.20673 6.30786 5.86678L6.36483 5.72816L6.93167 4.21289ZM13.8892 2C14.0208 2 14.1497 2.03368 14.2614 2.09721C14.373 2.16075 14.4629 2.25158 14.5208 2.3594L14.5545 2.43449L14.8007 3.09297L15.523 3.31759C15.6548 3.35847 15.7704 3.43415 15.8551 3.53504C15.9397 3.63593 15.9897 3.75749 15.9986 3.88431C16.0075 4.01113 15.9749 4.1375 15.905 4.24741C15.8351 4.35732 15.731 4.44582 15.6059 4.5017L15.523 4.5325L14.8014 4.75713L14.5552 5.41625C14.5104 5.53654 14.4274 5.64196 14.3168 5.71917C14.2062 5.79637 14.073 5.84188 13.934 5.84992C13.795 5.85796 13.6566 5.82818 13.5362 5.76434C13.4158 5.7005 13.3189 5.60549 13.2577 5.49134L13.2239 5.41625L12.9778 4.75777L12.2555 4.53314C12.1237 4.49227 12.0081 4.41659 11.9234 4.3157C11.8387 4.21481 11.7888 4.09325 11.7799 3.96643C11.771 3.83961 11.8036 3.71324 11.8735 3.60333C11.9434 3.49342 12.0475 3.40492 12.1725 3.34904L12.2555 3.31824L12.9771 3.09361L13.2232 2.43449C13.2706 2.30769 13.3604 2.19761 13.4798 2.11969C13.5992 2.04177 13.7424 1.99992 13.8892 2Z"
+        fill="url(#analyzeSparkleMain)"
+      />
+      <defs>
+        <linearGradient id="analyzeSparkleSmall" x1="9.31399" y1="15.5703" x2="9.31399" y2="16.0002" gradientUnits="userSpaceOnUse">
+          <stop className="analyze-sparkle-start" stopColor="#00E272" />
+          <stop className="analyze-sparkle-end" offset="1" stopColor="#A9FFD4" />
+        </linearGradient>
+        <linearGradient id="analyzeSparkleMain" x1="9" y1="2" x2="9" y2="14.7752" gradientUnits="userSpaceOnUse">
+          <stop className="analyze-sparkle-start" stopColor="#00E272" />
+          <stop className="analyze-sparkle-end" offset="1" stopColor="#A9FFD4" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}
+
 type Props = {
   form: DiagnosisFormState;
   derived: DiagnosisDerivedValues;
@@ -65,13 +90,12 @@ export default function FormSidebar({
         onClick={onAnalyze}
         disabled={disabled}
         aria-label={analyzing ? "분석 중" : "분석하기"}
-        className="relative mt-7 cursor-pointer disabled:cursor-not-allowed w-full aspect-[488/116] rounded-[5px] bg-[url('/analyze-button.png')] bg-contain bg-center bg-no-repeat drop-shadow-[2px_2px_5px_#D6FAE8] disabled:opacity-40 transition-opacity hover:opacity-90"
+        className="analyze-button mt-7 w-full h-11 inline-flex items-center justify-center gap-2.5 px-3 py-1.5 text-[14px] leading-[17px] tracking-[-0.02em] font-semibold text-black cursor-pointer disabled:cursor-not-allowed disabled:opacity-40"
       >
-        {analyzing && (
-          <span className="absolute inset-0 rounded-[5px] bg-card/85 grid place-items-center text-[14px] font-semibold text-ink">
-            분석 중…
-          </span>
-        )}
+        <span className="relative z-10 flex h-[18px] w-[18px] shrink-0 items-center justify-center">
+          <AnalyzeSparkleIcon />
+        </span>
+        <span className="relative z-10">{analyzing ? "분석 중…" : "분석하기"}</span>
       </button>
     </aside>
   );

--- a/src/components/debt-relief/hub/DiagnosisMobileCardList.tsx
+++ b/src/components/debt-relief/hub/DiagnosisMobileCardList.tsx
@@ -90,7 +90,7 @@ export default function DiagnosisMobileCardList({
               <div className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-1.5 min-w-0 flex-1">
                   <p className="text-[16px] font-semibold text-foreground truncate">{item.customerName}</p>
-                  {item.isShared && <LinkIcon size={14} className="text-primary-60 shrink-0" />}
+                  {item.isShared && <LinkIcon size={16} className="text-[#2563EB] shrink-0" />}
                 </div>
                 <span className="shrink-0">
                   <ProcedureBadge procedure={item.recommendedProcedure} />

--- a/src/components/debt-relief/hub/DiagnosisTable.tsx
+++ b/src/components/debt-relief/hub/DiagnosisTable.tsx
@@ -216,7 +216,7 @@ export default function DiagnosisTable({
                         <p className="text-[14px] font-semibold leading-[17px] text-foreground opacity-80 truncate">
                           {item.customerName}
                         </p>
-                        {item.isShared && <LinkIcon size={14} className="text-primary-80 shrink-0" />}
+                        {item.isShared && <LinkIcon size={16} className="text-[#2563EB] shrink-0" />}
                       </div>
                       {customerMeta ? (
                         <p className="text-[12px] font-medium leading-[14px] text-neutral-60 opacity-80">

--- a/src/components/debt-relief/hub/SummaryCards.tsx
+++ b/src/components/debt-relief/hub/SummaryCards.tsx
@@ -12,10 +12,10 @@ import SortIcon from "@/components/common/SortIcon";
 // 카드 외곽은 공통(304×148 비율)이되, 안쪽 콘텐츠 영역 너비·높이는 카드마다 다름 (피그마 Group 치수).
 const CARD_BASE =
   "bg-neutral-10 rounded-[14px] px-4 py-4 md:px-7 md:h-[148px] flex flex-col min-h-0";
-// 1~3번 카드: 상하 패딩 26px (정렬이 맞았던 기존 스펙)
-const CARD_CLASS = `${CARD_BASE} md:py-[26px]`;
+// 1~3번 카드: 상하 패딩 22px
+const CARD_CLASS = `${CARD_BASE} md:py-[22px]`;
 // 진행단계만 하단 패딩 14px — 공통 py를 쓰지 않고 pt/pb를 분리해 다른 카드에 영향 없게 함
-const CARD_PROGRESS_CLASS = `${CARD_BASE} md:pt-[26px] md:pb-3.5`;
+const CARD_PROGRESS_CLASS = `${CARD_BASE} md:pt-[22px] md:pb-3.5`;
 
 const LABEL_CLASS = "text-[13px] md:text-[14px] font-medium leading-[17px] text-neutral-60 shrink-0";
 
@@ -212,12 +212,12 @@ export default function SummaryCards({
         </div>
       </div>
 
-      {/* 진행단계 — 절차 셀렉트 + 스크롤 목록 */}
+      {/* 진행단계 — 절차 셀렉트 + 스크롤 목록 (제목·셀렉트 상단 22px 맞춤) */}
       <div className={CARD_PROGRESS_CLASS}>
-        <div className="flex items-center justify-between gap-2 shrink-0">
-          <div className="flex items-center gap-0.5 min-w-0">
+        <div className="flex items-start justify-between gap-2 shrink-0">
+          <div className="flex items-start gap-0.5 min-w-0">
             <p className={LABEL_CLASS}>진행단계</p>
-            <SortIcon state="none" className="-ml-0.5 shrink-0" />
+            <SortIcon state="none" className="-ml-0.5 -mt-0.5 shrink-0" />
           </div>
           <ProgressProcedureSelect value={selectedProcedure} onChange={setSelectedProcedure} />
         </div>

--- a/src/components/debt-relief/result/CustomerMatchModal.tsx
+++ b/src/components/debt-relief/result/CustomerMatchModal.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from "react";
 import { AnalysisService } from "@/services/analysis";
 import { showErrorModal } from "@/providers/ErrorFeedbackModalProvider";
 import Pagination from "@/components/common/Pagination";
+import { formatContactForDisplay } from "@/utils/format";
+import { formatDateTime } from "@/utils/datetime";
 import type { ConnectableCustomer } from "@/types/analysis";
 
 type Props = {
@@ -15,25 +17,54 @@ type Props = {
   onMatched: () => void;
 };
 
-const PAGE_LIMIT = 10;
+const PAGE_LIMIT = 5;
+
+const TABLE_HEADERS = ["이름", "연령", "전화번호", "담당팀", "담당자", "시간", "연동"] as const;
 
 function CloseIcon() {
   return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path d="M6 18L18 6M6 6L18 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <path
+        d="M6 18L18 6M6 6L18 18"
+        stroke="#B0B0B0"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </svg>
   );
 }
 
-function BackIcon() {
+function SearchIcon() {
   return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden>
-      <path d="M15 18L9 12L15 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <path
+        d="M17.5 17.5L12.5 12.5M14.1667 8.33333C14.1667 11.555 11.555 14.1667 8.33333 14.1667C5.11167 14.1667 2.5 11.555 2.5 8.33333C2.5 5.11167 5.11167 2.5 8.33333 2.5C11.555 2.5 14.1667 5.11167 14.1667 8.33333Z"
+        stroke="#B0B0B0"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </svg>
   );
 }
 
-export default function CustomerMatchModal({ open, onClose, onBack, analysisId, projectId, onMatched }: Props) {
+function getTeamName(customer: ConnectableCustomer): string {
+  return customer.assignedTeamName || customer.assignedMember?.team?.name || "-";
+}
+
+function getAssigneeName(customer: ConnectableCustomer): string {
+  return customer.assignedMemberName || customer.assignedMember?.name || "-";
+}
+
+export default function CustomerMatchModal({
+  open,
+  onClose,
+  onBack,
+  analysisId,
+  projectId,
+  onMatched,
+}: Props) {
   const [keyword, setKeyword] = useState("");
   const [debouncedKeyword, setDebouncedKeyword] = useState("");
   const [page, setPage] = useState(1);
@@ -42,7 +73,6 @@ export default function CustomerMatchModal({ open, onClose, onBack, analysisId, 
   const [loading, setLoading] = useState(false);
   const [matchingId, setMatchingId] = useState<number | null>(null);
 
-  // 검색어 300ms 디바운스 + 페이지 리셋
   useEffect(() => {
     if (!open) return;
     const timer = setTimeout(() => {
@@ -71,7 +101,10 @@ export default function CustomerMatchModal({ open, onClose, onBack, analysisId, 
       .catch((error) => {
         if (cancelled) return;
         console.error("Failed to load connectable customers:", error);
-        showErrorModal({ headline: "고객 목록을 불러오지 못했습니다.", description: "잠시 후 다시 시도해주세요." });
+        showErrorModal({
+          headline: "고객 목록을 불러오지 못했습니다.",
+          description: "잠시 후 다시 시도해주세요.",
+        });
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -82,15 +115,25 @@ export default function CustomerMatchModal({ open, onClose, onBack, analysisId, 
     };
   }, [open, analysisId, projectId, debouncedKeyword, page]);
 
-  // 닫힐 때 검색 상태 초기화 (다음에 열 때 깨끗하게 시작)
   useEffect(() => {
     if (!open) {
       setKeyword("");
       setDebouncedKeyword("");
       setPage(1);
       setCustomers([]);
+      setTotal(0);
+      setMatchingId(null);
     }
   }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !matchingId) onClose();
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [open, matchingId, onClose]);
 
   const handleMatch = async (customerId: number) => {
     if (matchingId) return;
@@ -108,7 +151,10 @@ export default function CustomerMatchModal({ open, onClose, onBack, analysisId, 
           description: "새로고침 후 다시 시도해주세요.",
         });
       } else {
-        showErrorModal({ headline: "고객 연결에 실패했습니다.", description: "잠시 후 다시 시도해주세요." });
+        showErrorModal({
+          headline: "고객 연결에 실패했습니다.",
+          description: "잠시 후 다시 시도해주세요.",
+        });
       }
     } finally {
       setMatchingId(null);
@@ -118,85 +164,223 @@ export default function CustomerMatchModal({ open, onClose, onBack, analysisId, 
   if (!open) return null;
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_LIMIT));
+  const handleCancel = onBack ?? onClose;
 
   return (
-    <>
-      <div className="fixed inset-0 bg-black/50 dark:bg-[#000000CC] z-40" onClick={onClose} aria-hidden />
-      <div
-        className="fixed left-4 right-4 top-1/2 -translate-y-1/2 md:left-1/2 md:right-auto md:w-[480px] md:-translate-x-1/2 w-[calc(100%-2rem)] max-h-[80vh] bg-card dark:bg-neutral-10 rounded-[14px] z-50 flex flex-col overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between px-6 pt-5 pb-4 shrink-0">
-          <div className="flex items-center gap-2 min-w-0">
-            {onBack && (
-              <button
-                type="button"
-                onClick={onBack}
-                aria-label="뒤로가기"
-                className="cursor-pointer w-6 h-6 grid place-items-center text-neutral-60 hover:opacity-70 shrink-0"
+    <div className="fixed inset-0 z-50 bg-black/50 dark:bg-[#000000CC]">
+      <div className="w-full h-full p-0 md:h-auto md:min-h-full md:flex md:items-center md:justify-center md:p-4">
+        <div
+          className="w-full h-full md:w-[848px] md:h-[625px] md:max-h-[90vh] rounded-t-[14px] md:rounded-[14px] bg-neutral-0 dark:bg-neutral-10 flex flex-col shadow-[0px_13px_61px_rgba(169,169,169,0.366013)] drop-shadow-[0px_8px_12px_rgba(9,30,66,0.1)] dark:shadow-none dark:drop-shadow-none"
+          onClick={(event) => event.stopPropagation()}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="customer-match-modal-title"
+        >
+          <div className="flex items-start justify-between gap-4 px-4 md:px-7 pt-5 md:pt-6 shrink-0">
+            <div className="min-w-0">
+              <h2
+                id="customer-match-modal-title"
+                className="text-[18px] font-semibold leading-[21px] text-foreground"
               >
-                <BackIcon />
-              </button>
-            )}
-            <h2 className="text-[18px] font-semibold text-foreground">고객 연결</h2>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="닫기"
-            className="cursor-pointer w-6 h-6 grid place-items-center text-neutral-60 hover:opacity-70"
-          >
-            <CloseIcon />
-          </button>
-        </div>
-
-        <div className="px-6 pb-3 shrink-0">
-          <input
-            value={keyword}
-            onChange={(e) => setKeyword(e.target.value)}
-            placeholder="이름 또는 연락처로 검색"
-            className="w-full h-[38px] px-3 rounded-[8px] border border-neutral-30 bg-card text-[14px] text-foreground placeholder:text-neutral-50 focus:outline-none focus:border-neutral-50"
-          />
-        </div>
-
-        <div className="overflow-y-auto px-6 pb-4 flex-1 min-h-[200px]">
-          {loading ? (
-            <div className="flex items-center justify-center py-10 text-[14px] text-neutral-60">불러오는 중...</div>
-          ) : customers.length === 0 ? (
-            <div className="flex items-center justify-center py-10 text-[14px] text-neutral-60">
-              연결 가능한 고객이 없습니다.
+                고객연동
+              </h2>
+              <p className="mt-3 text-[14px] font-medium leading-[17px] tracking-[0.2px] text-neutral-60">
+                현재 자신에게 할당된 고객 중 아직 연동이 안된 고객 목록입니다.
+              </p>
             </div>
-          ) : (
-            <div className="flex flex-col gap-2">
-              {customers.map((customer) => (
-                <div
-                  key={customer.id}
-                  className="flex items-center justify-between gap-3 h-[52px] px-4 rounded-[8px] bg-neutral-10"
-                >
-                  <div className="min-w-0">
-                    <p className="text-[14px] font-semibold text-foreground truncate">{customer.name}</p>
-                    <p className="text-[12px] text-neutral-60 truncate">{customer.contact1}</p>
-                  </div>
-                  <button
-                    type="button"
-                    disabled={matchingId === customer.id}
-                    onClick={() => handleMatch(customer.id)}
-                    className="cursor-pointer shrink-0 h-[30px] px-3 rounded-[5px] bg-neutral-90 text-neutral-20 text-[13px] font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={Boolean(matchingId)}
+              aria-label="닫기"
+              className="cursor-pointer w-6 h-6 grid place-items-center shrink-0 mt-0.5 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <CloseIcon />
+            </button>
+          </div>
+
+          <div className="mx-4 md:mx-7 mt-4 border-b border-neutral-30 shrink-0" />
+
+          <div className="flex-1 min-h-0 overflow-y-auto px-4 md:px-7 pt-3 pb-4 flex flex-col">
+            <div className="relative w-full md:w-[200px] shrink-0">
+              <input
+                value={keyword}
+                onChange={(event) => setKeyword(event.target.value)}
+                placeholder="이름 연락처로 검색..."
+                disabled={Boolean(matchingId)}
+                className="w-full h-[34px] px-3 pr-10 rounded-[5px] border border-neutral-30 bg-card text-[12px] font-medium leading-[14px] tracking-[-0.02em] text-foreground placeholder:text-neutral-60 focus:outline-none focus:border-neutral-50 disabled:opacity-60"
+              />
+              <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2">
+                <SearchIcon />
+              </span>
+            </div>
+
+            <div className="hidden md:block mt-3 overflow-hidden rounded-[8px] flex-1 min-h-0">
+              <table className="w-full text-left border-collapse table-fixed">
+                <thead>
+                  <tr className="bg-neutral-20 text-neutral-60">
+                    {TABLE_HEADERS.map((header, index) => (
+                      <th
+                        key={header}
+                        className={`h-10 px-3 text-[16px] font-medium leading-[19px] ${
+                          index === 0 ? "rounded-l-[8px] w-[88px]" : ""
+                        } ${index === 1 ? "w-[56px]" : ""} ${index === 2 ? "w-[140px]" : ""} ${
+                          index === 3 ? "w-[96px]" : ""
+                        } ${index === 4 ? "w-[72px]" : ""} ${index === 5 ? "w-[140px]" : ""} ${
+                          index === 6 ? "rounded-r-[8px] w-[72px] text-center" : ""
+                        }`}
+                      >
+                        {header}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {loading &&
+                    Array.from({ length: PAGE_LIMIT }).map((_, rowIndex) => (
+                      <tr key={`skeleton-${rowIndex}`} className="border-b border-neutral-30 animate-pulse">
+                        {Array.from({ length: 7 }).map((__, cellIndex) => (
+                          <td key={cellIndex} className="h-[59px] px-3 align-middle">
+                            <div
+                              className="h-3 rounded bg-neutral-20"
+                              style={{
+                                width: cellIndex === 2 ? 120 : cellIndex === 5 ? 100 : 48,
+                              }}
+                            />
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+
+                  {!loading && customers.length === 0 && (
+                    <tr>
+                      <td colSpan={7} className="h-[240px] text-center text-[14px] text-neutral-60">
+                        연동 가능한 고객이 없습니다.
+                      </td>
+                    </tr>
+                  )}
+
+                  {!loading &&
+                    customers.map((customer) => (
+                      <tr key={customer.id} className="border-b border-neutral-30">
+                        <td className="h-[59px] px-3 align-middle text-[14px] font-medium text-neutral-90 opacity-80 truncate">
+                          {customer.name || "-"}
+                        </td>
+                        <td className="h-[59px] px-3 align-middle text-[14px] font-medium text-neutral-90 opacity-80 truncate">
+                          {customer.ageRange || "-"}
+                        </td>
+                        <td className="h-[59px] px-3 align-middle text-[14px] font-semibold text-neutral-90 opacity-80 truncate">
+                          {formatContactForDisplay(customer.contact1) || "-"}
+                        </td>
+                        <td className="h-[59px] px-3 align-middle text-[14px] font-medium text-neutral-90 opacity-80 truncate">
+                          {getTeamName(customer)}
+                        </td>
+                        <td className="h-[59px] px-3 align-middle text-[14px] font-medium text-neutral-90 opacity-80 truncate">
+                          {getAssigneeName(customer)}
+                        </td>
+                        <td className="h-[59px] px-3 align-middle text-[14px] font-medium text-neutral-90 opacity-80 whitespace-nowrap">
+                          {formatDateTime(customer.applicationDate)}
+                        </td>
+                        <td className="h-[59px] px-3 align-middle text-center">
+                          <button
+                            type="button"
+                            disabled={matchingId === customer.id}
+                            onClick={() => handleMatch(customer.id)}
+                            className="cursor-pointer inline-flex items-center justify-center h-[34px] min-w-[48px] px-3 rounded-[5px] bg-neutral-90 text-neutral-20 text-[14px] font-semibold leading-[17px] tracking-[-0.02em] disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            {matchingId === customer.id ? "..." : "연동"}
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="md:hidden mt-3 space-y-3 flex-1 min-h-0">
+              {loading &&
+                Array.from({ length: PAGE_LIMIT }).map((_, index) => (
+                  <div
+                    key={`mobile-skeleton-${index}`}
+                    className="rounded-[12px] border border-neutral-30 p-4 animate-pulse"
                   >
-                    {matchingId === customer.id ? "연결 중..." : "연결"}
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+                    <div className="h-4 w-1/3 bg-neutral-20 rounded mb-2" />
+                    <div className="h-3 w-1/2 bg-neutral-20 rounded" />
+                  </div>
+                ))}
 
-        {totalPages > 1 && (
-          <div className="flex justify-center pb-4 shrink-0">
-            <Pagination page={page} totalPages={totalPages} onPageChange={setPage} disabled={loading} maxButtons={5} />
+              {!loading && customers.length === 0 && (
+                <div className="h-[160px] flex items-center justify-center text-[14px] text-neutral-60">
+                  연동 가능한 고객이 없습니다.
+                </div>
+              )}
+
+              {!loading &&
+                customers.map((customer) => (
+                  <div
+                    key={customer.id}
+                    className="rounded-[12px] border border-neutral-30 bg-card p-4"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="text-[16px] font-semibold text-foreground truncate">
+                          {customer.name || "-"}
+                        </p>
+                        <p className="mt-1 text-[14px] text-neutral-60">
+                          {customer.ageRange ? `${customer.ageRange} · ` : ""}
+                          <span className="font-semibold text-foreground">
+                            {formatContactForDisplay(customer.contact1) || "-"}
+                          </span>
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        disabled={matchingId === customer.id}
+                        onClick={() => handleMatch(customer.id)}
+                        className="cursor-pointer shrink-0 h-[34px] min-w-[48px] px-3 rounded-[5px] bg-neutral-90 text-neutral-20 text-[14px] font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        {matchingId === customer.id ? "..." : "연동"}
+                      </button>
+                    </div>
+                    <div className="mt-3 pt-3 border-t border-neutral-30 flex flex-wrap gap-x-4 gap-y-1 text-[12px] text-neutral-60">
+                      <span>담당팀: {getTeamName(customer)}</span>
+                      <span>담당자: {getAssigneeName(customer)}</span>
+                      <span>시간: {formatDateTime(customer.applicationDate)}</span>
+                    </div>
+                  </div>
+                ))}
+            </div>
+
+            <div className="mt-4 flex items-center justify-between gap-3 shrink-0">
+              <span className="text-[14px] font-medium leading-5 text-neutral-50 whitespace-nowrap">
+                총 {total.toLocaleString("ko-KR")}건
+              </span>
+              <Pagination
+                page={page}
+                totalPages={totalPages}
+                onPageChange={setPage}
+                disabled={loading || Boolean(matchingId)}
+                maxButtons={10}
+                className="justify-center"
+              />
+              <div className="w-[52px] hidden md:block" aria-hidden />
+            </div>
           </div>
-        )}
+
+          <div className="mx-4 md:mx-7 border-t border-neutral-30 shrink-0" />
+
+          <div className="flex justify-end px-4 md:px-7 py-4 shrink-0">
+            <button
+              type="button"
+              onClick={handleCancel}
+              disabled={Boolean(matchingId)}
+              className="cursor-pointer h-[34px] px-3 rounded-[5px] border border-neutral-30 bg-card text-[14px] font-semibold leading-[17px] tracking-[-0.02em] text-foreground hover:bg-neutral-10 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              취소
+            </button>
+          </div>
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/debt-relief/result/DiagnosisCustomerInfoModal.tsx
+++ b/src/components/debt-relief/result/DiagnosisCustomerInfoModal.tsx
@@ -400,7 +400,7 @@ function buildSections(
 }
 
 /**
- * 변호사 상세 「고객정보」 모달.
+ * 진단 상세 「고객정보」 모달.
  * GET /v1/analysis/{id} 의 inputData + contact + referenceNote 만 사용합니다.
  * /v1/customers 는 호출하지 않습니다.
  */

--- a/src/components/debt-relief/result/ResultHeader.tsx
+++ b/src/components/debt-relief/result/ResultHeader.tsx
@@ -110,7 +110,7 @@ function LinkedCustomerIcon({ className }: { className?: string }) {
 }
 
 const ACTION_BTN =
-  "cursor-pointer inline-flex items-center justify-center gap-2.5 h-[34px] px-3 rounded-[5px] border border-neutral-30 text-[14px] font-semibold leading-[17px] tracking-[-0.02em] text-black hover:bg-neutral-10 whitespace-nowrap";
+  "cursor-pointer inline-flex items-center justify-center gap-2.5 h-[34px] px-3 rounded-[5px] border border-neutral-30 text-[14px] font-semibold leading-[17px] tracking-[-0.02em] text-black dark:text-foreground hover:bg-neutral-10 whitespace-nowrap";
 
 const LINKED_CHIP_BTN =
   "cursor-pointer inline-flex items-center justify-center gap-2.5 h-[34px] max-w-[244px] px-[7px] py-1.5 rounded-[5px] bg-secondary-10 border border-secondary-60 text-secondary-40 hover:opacity-90 transition-opacity";
@@ -354,7 +354,7 @@ export default function ResultHeader({ detail, projectId, onCustomerMatchChange 
               <p className="text-[13px] font-medium leading-4 text-neutral-60 truncate min-w-0">
                 {customerSummaryLabel}
               </p>
-              {showAssigneeProfile ? customerInfoButton : null}
+              {customerInfoButton}
             </div>
           </div>
         </div>
@@ -419,7 +419,7 @@ export default function ResultHeader({ detail, projectId, onCustomerMatchChange 
             type="button"
             onClick={handleGoToList}
             aria-label="목록으로"
-            className="cursor-pointer w-6 h-6 flex items-center justify-center text-black hover:opacity-70 shrink-0"
+            className="cursor-pointer w-6 h-6 flex items-center justify-center text-black dark:text-foreground hover:opacity-70 shrink-0"
           >
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
               <path
@@ -438,7 +438,7 @@ export default function ResultHeader({ detail, projectId, onCustomerMatchChange 
           <span className="text-[18px] font-medium leading-5 text-neutral-60 truncate min-w-0">
             {customerSummaryLabel}
           </span>
-          {showAssigneeProfile ? customerInfoButton : null}
+          {customerInfoButton}
         </div>
 
         {showOwnerActions ? (
@@ -468,7 +468,7 @@ export default function ResultHeader({ detail, projectId, onCustomerMatchChange 
                 type="button"
                 onClick={handleOpenMatchModal}
                 aria-label="고객 연결"
-                className="cursor-pointer w-[34px] h-[34px] flex items-center justify-center rounded-[5px] border border-neutral-30 text-black hover:bg-neutral-10"
+                className="cursor-pointer w-[34px] h-[34px] flex items-center justify-center rounded-[5px] border border-neutral-30 text-black dark:text-foreground hover:bg-neutral-10"
               >
                 <LinkedCustomerIcon />
               </button>
@@ -515,7 +515,7 @@ export default function ResultHeader({ detail, projectId, onCustomerMatchChange 
           />
         </>
       )}
-      {showAssigneeProfile && projectId && (
+      {projectId && (
         <DiagnosisCustomerInfoModal
           open={customerInfoOpen}
           onClose={() => setCustomerInfoOpen(false)}

--- a/src/components/debt-relief/result/SectionProcedureGuide.tsx
+++ b/src/components/debt-relief/result/SectionProcedureGuide.tsx
@@ -18,6 +18,7 @@ function SmsButton({ onClick, disabled }: { onClick: () => void; disabled?: bool
       onClick={onClick}
       disabled={disabled}
       aria-label="문자 보내기"
+      title={disabled ? "연락처 정보가 없어 문자 발송이 불가능합니다" : undefined}
       className={`inline-flex items-center justify-center gap-1 h-9 w-9 md:h-[34px] md:w-auto md:px-3 rounded-[5px] border border-neutral-30 bg-neutral-0 text-[14px] font-semibold leading-[17px] tracking-[-0.02em] text-neutral-60 ${
         disabled ? "opacity-40 cursor-not-allowed" : "cursor-pointer hover:bg-neutral-10"
       }`}
@@ -255,7 +256,9 @@ export default function SectionProcedureGuide({ detail, onSetCurrentStep }: Prop
   const [optimisticHistory, setOptimisticHistory] = useState<
     Record<number, ProcedureStepHistoryItem>
   >({});
-  const canSendSms = Boolean(detail.customerId);
+  // 서버는 공유 시 전달받은 연락처를 우선 쓰고, 없으면 매칭된 고객 연락처를 쓴다 — detail.phone이
+  // 이미 그 결과를 반영하므로 phone 유무로만 판단한다(SectionSmsSend.tsx 참고).
+  const canSendSms = Boolean(detail.phone);
 
   const historyByStepId = useMemo(() => {
     const map = new Map<number, ProcedureStepHistoryItem>();

--- a/src/components/debt-relief/result/SectionSmsSend.tsx
+++ b/src/components/debt-relief/result/SectionSmsSend.tsx
@@ -74,8 +74,9 @@ const ACTION_BUILDERS: {
 
 export default function SectionSmsSend({ detail }: { detail: DiagnosisDetail }) {
   const [smsTemplate, setSmsTemplate] = useState<SmsTemplate | null>(null);
-  // 고객 매칭(customerId)이 없으면 실 연락처가 없어 문자를 보낼 수 없다.
-  const canSendSms = Boolean(detail.customerId);
+  // 서버는 공유 시 전달받은 연락처를 우선 쓰고, 없으면 매칭된 고객 연락처를 쓴다(getDiagnosisDetail
+  // 참고). detail.phone이 이미 그 결과를 반영하므로 phone 유무로만 판단하면 된다.
+  const canSendSms = Boolean(detail.phone);
 
   return (
     <div className="flex items-center gap-2 flex-wrap">
@@ -94,7 +95,7 @@ export default function SectionSmsSend({ detail }: { detail: DiagnosisDetail }) 
         </button>
       ))}
       <span className="text-[14px] text-neutral-60">
-        {canSendSms ? `${detail.customerName} ${detail.phone}` : "고객 매칭 후 문자 발송이 가능합니다"}
+        {canSendSms ? `${detail.customerName} ${detail.phone}` : "연락처 정보가 없어 문자 발송이 불가능합니다"}
       </span>
 
       {smsTemplate && (

--- a/src/components/debt-relief/result/SuccessDonut.tsx
+++ b/src/components/debt-relief/result/SuccessDonut.tsx
@@ -44,7 +44,7 @@ export default function SuccessDonut({
             cy={center}
             r={radius}
             fill="none"
-            stroke="#F2F3F7"
+            stroke="var(--neutral-30)"
             strokeWidth={stroke}
           />
           <circle

--- a/src/components/debt-relief/result/sms/DebtReliefPhonePreview.tsx
+++ b/src/components/debt-relief/result/sms/DebtReliefPhonePreview.tsx
@@ -7,8 +7,7 @@ import type { ImageFileWithPreview, ContentType } from "@/components/customers/s
 type DebtReliefPhonePreviewProps = {
   senderNumber: string;
   title: string;
-  fixedBlock: string; // 고정 안내문 (읽기 전용, 항상 본문 위에 표시)
-  body: string; // 사용자가 편집하는 본문
+  body: string;
   imageFiles: ImageFileWithPreview[];
   contentType: ContentType;
   businessName: string;
@@ -26,19 +25,15 @@ function buildHeaderLine(contentType: ContentType, title: string, businessName: 
 
 function MessageBubble({
   headerLine,
-  fixedBlock,
   body,
   imageFiles,
   bubbleClassName,
 }: {
   headerLine: string | null;
-  fixedBlock: string;
   body: string;
   imageFiles: ImageFileWithPreview[];
   bubbleClassName: string;
 }) {
-  const combined = [fixedBlock, body].filter((part) => part.trim().length > 0).join("\n\n");
-
   return (
     <>
       <div className={bubbleClassName}>
@@ -49,7 +44,9 @@ function MessageBubble({
         )}
         <div className="text-[13px] leading-[20px] text-neutral-80 dark:text-neutral-70 whitespace-pre-wrap break-words">
           <span className="block mb-1">[Web발신]</span>
-          {combined || (
+          {body.trim() ? (
+            body
+          ) : (
             <span className="text-neutral-50 dark:text-neutral-50">메시지 내용이 여기에 표시됩니다.</span>
           )}
         </div>
@@ -74,7 +71,6 @@ function MessageBubble({
 export default function DebtReliefPhonePreview({
   senderNumber,
   title,
-  fixedBlock,
   body,
   imageFiles,
   contentType,
@@ -162,7 +158,6 @@ export default function DebtReliefPhonePreview({
           <div className="pt-2 pb-4 flex flex-col items-start px-4">
             <MessageBubble
               headerLine={headerLine}
-              fixedBlock={fixedBlock}
               body={body}
               imageFiles={imageFiles}
               bubbleClassName="bg-neutral-20 dark:bg-neutral-20 rounded-[12px] p-4 max-w-[90%]"
@@ -207,7 +202,6 @@ export default function DebtReliefPhonePreview({
           <div className="px-4 pt-2 pb-4 flex flex-col items-start">
             <MessageBubble
               headerLine={headerLine}
-              fixedBlock={fixedBlock}
               body={body}
               imageFiles={imageFiles}
               bubbleClassName="bg-neutral-10 dark:bg-neutral-20 rounded-[12px] p-4 max-w-[85%]"

--- a/src/components/debt-relief/result/sms/DebtReliefSmsModal.tsx
+++ b/src/components/debt-relief/result/sms/DebtReliefSmsModal.tsx
@@ -17,7 +17,6 @@ export type DebtReliefSmsModalProps = {
   onClose: () => void;
   diagnosisId: string;
   subtitle: string;
-  fixedBlock: string;
   initialBody: string;
   recipientName: string;
   recipientPhone: string;
@@ -28,7 +27,6 @@ export default function DebtReliefSmsModal({
   onClose,
   diagnosisId,
   subtitle,
-  fixedBlock,
   initialBody,
   recipientName,
   recipientPhone,
@@ -69,7 +67,9 @@ export default function DebtReliefSmsModal({
 
   const [uploadingImages, setUploadingImages] = useState(false);
   const [isMobilePreviewOpen, setIsMobilePreviewOpen] = useState(false);
-  const prevOpenRef = useRef(open);
+  // 부모에서 `{smsTemplate && <Modal open />}` 로 마운트하면 첫 open이 true라서
+  // prev를 open으로 초기화하면 열림 전환을 놓쳐 템플릿 본문이 세팅되지 않는다.
+  const prevOpenRef = useRef(false);
 
   // 모달이 열릴 때 발신번호/상호명 로드 + 템플릿 본문으로 초기화, 닫힐 때 폼 리셋
   useEffect(() => {
@@ -133,14 +133,12 @@ export default function DebtReliefSmsModal({
         }
       }
 
-      const content = [fixedBlock, body].filter((part) => part.trim().length > 0).join("\n\n");
-
       const result = await handleSend({
         projectId,
         diagnosisId,
         recipientName,
         recipientPhone,
-        content,
+        content: body,
         imageUrls,
       });
 
@@ -283,7 +281,7 @@ export default function DebtReliefSmsModal({
         </div>
 
         {contentType === "advertising" && (
-          <div className="mt-3">
+          <div className="mt-5">
             <label className="block text-[13px] leading-[16px] text-neutral-60 dark:text-neutral-60 mb-2">상호명</label>
             <input
               type="text"
@@ -311,17 +309,12 @@ export default function DebtReliefSmsModal({
       {/* 본문 */}
       <div className="mb-5">
         <label className="block text-[14px] leading-[17px] text-neutral-60 dark:text-neutral-60 mb-2">본문</label>
-        {fixedBlock && (
-          <div className="mb-2 rounded-[5px] bg-neutral-10 dark:bg-neutral-20 px-3 py-2 text-[13px] leading-[19px] text-neutral-60 dark:text-neutral-60 whitespace-pre-wrap">
-            {fixedBlock}
-          </div>
-        )}
         <textarea
           value={body}
           onChange={(e) => setBody(e.target.value)}
           placeholder="발송할 메시지를 입력하세요"
-          rows={4}
-          className="w-full px-3 py-2 border border-neutral-30 dark:border-neutral-30 rounded-[5px] text-[14px] leading-[1] tracking-[-0.02em] text-ink dark:text-neutral-90 placeholder:text-neutral-60 dark:placeholder:text-neutral-60 bg-card dark:bg-neutral-10 outline-none focus:border-neutral-60 dark:focus:border-neutral-60 resize-none"
+          rows={10}
+          className="w-full px-3 py-2 border border-neutral-30 dark:border-neutral-30 rounded-[5px] text-[14px] leading-[1.4] tracking-[-0.02em] text-ink dark:text-neutral-90 placeholder:text-neutral-60 dark:placeholder:text-neutral-60 bg-card dark:bg-neutral-10 outline-none focus:border-neutral-60 dark:focus:border-neutral-60 resize-none"
         />
       </div>
 
@@ -470,7 +463,6 @@ export default function DebtReliefSmsModal({
             <DebtReliefPhonePreview
               senderNumber={selectedSender?.phoneNumber ?? "010-0000-0000"}
               title={title}
-              fixedBlock={fixedBlock}
               body={body}
               imageFiles={imageFiles}
               contentType={contentType}
@@ -489,7 +481,6 @@ export default function DebtReliefSmsModal({
             <DebtReliefPhonePreview
               senderNumber={selectedSender?.phoneNumber ?? "010-0000-0000"}
               title={title}
-              fixedBlock={fixedBlock}
               body={body}
               imageFiles={imageFiles}
               contentType={contentType}

--- a/src/components/debt-relief/result/sms/templates.ts
+++ b/src/components/debt-relief/result/sms/templates.ts
@@ -1,12 +1,10 @@
 import type { DiagnosisDetail, ProcedureStep, ProcedureStepNoteType } from "@/types/debtRelief";
 import { RECOMMENDED_PROCEDURE_LABEL, PROCEDURE_GRADE_LABEL } from "@/types/debtRelief";
 
-// 문자 모달에 채워 넣을 안내문 세트.
-// fixedBlock: 미리보기 상단에 항상 포함되는 고정 안내문(읽기 전용, 본문 입력창에는 노출되지 않음)
-// initialBody: 본문 입력창의 초기값(발송 전 자유롭게 수정 가능)
+// 문자 모달 본문 입력창에 미리 채워 넣는 안내문 세트.
+// initialBody는 발송 전 자유롭게 수정 가능하다.
 export type SmsTemplate = {
   subtitle: string;
-  fixedBlock: string;
   initialBody: string;
 };
 
@@ -15,6 +13,10 @@ const NOTE_LABEL: Record<ProcedureStepNoteType, string> = {
   info: "ℹ 참고사항",
   default: "안내",
 };
+
+function joinParts(...parts: string[]): string {
+  return parts.filter((part) => part.trim().length > 0).join("\n\n");
+}
 
 // 절차안내 단계별 "문자" 버튼
 export function buildProcedureStepTemplate(detail: DiagnosisDetail, step: ProcedureStep): SmsTemplate {
@@ -31,10 +33,11 @@ export function buildProcedureStepTemplate(detail: DiagnosisDetail, step: Proced
     lines.push("", "■ 주요 내용", ...step.checklist.map((item) => `· ${item}`));
   }
 
+  const noteBody = step.note ? `${NOTE_LABEL[step.noteType ?? "default"]}\n${step.note}` : "";
+
   return {
     subtitle: `${step.step}단계. ${step.title}`,
-    fixedBlock: lines.join("\n"),
-    initialBody: step.note ? `${NOTE_LABEL[step.noteType ?? "default"]}\n${step.note}` : "",
+    initialBody: joinParts(lines.join("\n"), noteBody),
   };
 }
 
@@ -49,7 +52,7 @@ function buildIncomeProofLine(occupation: string): string {
 // 하단 "필요 서류 안내" 버튼
 export function buildRequiredDocsTemplate(detail: DiagnosisDetail): SmsTemplate {
   const procedureLabel = RECOMMENDED_PROCEDURE_LABEL[detail.recommendedProcedure];
-  const fixedBlock = [
+  const docsBlock = [
     `안녕하세요, ${detail.customerName} 고객님.`,
     "",
     `${procedureLabel} 신청을 위해 아래 서류를 준비해주시기 바랍니다.`,
@@ -57,27 +60,22 @@ export function buildRequiredDocsTemplate(detail: DiagnosisDetail): SmsTemplate 
     "[필수 서류]",
     "✅ 주민등록등본 1부",
     `✅ ${buildIncomeProofLine(detail.occupation)}`,
-    "✅ 채무 증명서류 (각 금융기관 대출 잔액 증명서)",
+    "✅ 채무 증명서류 (각 금융기관 채무 잔액 증명서)",
     "✅ 재산 목록 (부동산·차량 없을 시 무재산 확인서)",
     "✅ 가족관계증명서 1부",
   ].join("\n");
 
   return {
     subtitle: "필요 서류 안내",
-    fixedBlock,
-    initialBody: "서류 준비에 어려움이 있으시면 언제든지 연락 주세요.\n\n감사합니다.",
+    initialBody: joinParts(docsBlock, "서류 준비에 어려움이 있으시면 언제든지 연락 주세요.\n\n감사합니다."),
   };
 }
 
 // 하단 "상담 일정 안내" 버튼
-// 상담 일시/장소는 진단 데이터에 없는 값이라 자동으로 채울 수 없으므로,
-// 인사말만 고정 블록으로 두고 나머지는 상담원이 채워 넣는 본문(수정 가능)에 둔다.
 export function buildConsultScheduleTemplate(detail: DiagnosisDetail): SmsTemplate {
-  const fixedBlock = [`안녕하세요, ${detail.customerName} 고객님.`, "", "다음 상담 일정을 안내드립니다."].join(
-    "\n"
-  );
+  const intro = [`안녕하세요, ${detail.customerName} 고객님.`, "", "다음 상담 일정을 안내드립니다."].join("\n");
 
-  const initialBody = [
+  const scheduleBody = [
     "📅 일정: (상담 일시를 입력해주세요)",
     "📍 장소: 사무실 내방 (또는 전화 상담)",
     "⏱ 소요 시간: 약 60분",
@@ -89,7 +87,7 @@ export function buildConsultScheduleTemplate(detail: DiagnosisDetail): SmsTempla
     "감사합니다.",
   ].join("\n");
 
-  return { subtitle: "상담 일정 안내", fixedBlock, initialBody };
+  return { subtitle: "상담 일정 안내", initialBody: joinParts(intro, scheduleBody) };
 }
 
 // 분석결과 요약에 넣을 근거 문구 3개 선정: met → caution 순으로 우선순위를 두고,
@@ -111,7 +109,7 @@ export function buildAnalysisShareTemplate(detail: DiagnosisDetail): SmsTemplate
   const score = detail.procedureScores.find((s) => s.procedure === detail.recommendedProcedure);
   const gradeLabel = score ? PROCEDURE_GRADE_LABEL[score.grade] : "";
 
-  const fixedBlock = [
+  const summaryBlock = [
     `안녕하세요, ${detail.customerName} 고객님.`,
     "",
     "분석 결과를 공유드립니다.",
@@ -125,12 +123,11 @@ export function buildAnalysisShareTemplate(detail: DiagnosisDetail): SmsTemplate
 
   return {
     subtitle: "분석결과 공유",
-    fixedBlock,
-    initialBody: "자세한 내용은 상담 시 설명드리겠습니다.\n\n감사합니다.",
+    initialBody: joinParts(summaryBlock, "자세한 내용은 상담 시 설명드리겠습니다.\n\n감사합니다."),
   };
 }
 
-// 하단 "직접작성" 버튼 - 고정 안내문 없이 자유 작성
+// 하단 "직접작성" 버튼 - 빈 본문으로 자유 작성
 export function buildBlankTemplate(): SmsTemplate {
-  return { subtitle: "직접작성", fixedBlock: "", initialBody: "" };
+  return { subtitle: "직접작성", initialBody: "" };
 }

--- a/src/components/icons/LinkIcon.tsx
+++ b/src/components/icons/LinkIcon.tsx
@@ -1,19 +1,19 @@
-/** 공유 링크 아이콘 */
+/** 연동(링크) 아이콘 */
 export default function LinkIcon({ size = 16, className }: { size?: number; className?: string }) {
   return (
     <svg
       width={size}
       height={size}
-      viewBox="0 0 24 24"
+      viewBox="0 0 16 16"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={className}
       aria-hidden
     >
       <path
-        d="M15 7H17C19.7614 7 22 9.23858 22 12C22 14.7614 19.7614 17 17 17H15M9 17H7C4.23858 17 2 14.7614 2 12C2 9.23858 4.23858 7 7 7H9M8 12H16"
+        d="M9.21895 6.78105C8.17755 5.73965 6.48911 5.73965 5.44772 6.78105L2.78105 9.44772C1.73965 10.4891 1.73965 12.1776 2.78105 13.219C3.82245 14.2603 5.51089 14.2603 6.55228 13.219L7.28666 12.4846M6.78105 9.21895C7.82245 10.2603 9.51089 10.2604 10.5523 9.21895L13.219 6.55228C14.2603 5.51089 14.2603 3.82245 13.219 2.78105C12.1776 1.73965 10.4891 1.73965 9.44772 2.78105L8.71464 3.51412"
         stroke="currentColor"
-        strokeWidth="2"
+        strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"
       />

--- a/src/services/analysis.ts
+++ b/src/services/analysis.ts
@@ -27,6 +27,8 @@ import type {
   AnalysisSummaryResponse,
   AnalysisProceduresResponse,
   AnalysisProcedureChangesResponse,
+  AnalysisSendSmsInput,
+  AnalysisSendSmsResponse,
   BulkDeleteAnalysisInput,
   BulkDeleteAnalysisResponse,
   BulkDeliverAnalysisInput,
@@ -245,6 +247,13 @@ export const AnalysisService = {
   // 절차 마스터 데이터 조회
   procedures(projectId: string) {
     return apiClient.get<AnalysisProceduresResponse>(`/v1/analysis/procedures`, {
+      headers: { "x-project-id": projectId },
+    });
+  },
+
+  // 분석 건 연락처로 문자 발송 (공유 시 전달받은 연락처 우선, 없으면 매칭된 고객 연락처)
+  sendSms(id: number, projectId: string, input: AnalysisSendSmsInput) {
+    return apiClient.post<AnalysisSendSmsResponse>(`/v1/analysis/${id}/send-sms`, input, {
       headers: { "x-project-id": projectId },
     });
   },

--- a/src/services/debtRelief.ts
+++ b/src/services/debtRelief.ts
@@ -59,7 +59,10 @@ import type {
   CreateAnalysisInput,
 } from "@/types/analysis";
 
-// 남은 mock: sendGuidanceSms(문자 발송, Phase 3). 목록 정렬은 GET /v1/analysis의
+// sendGuidanceSms(문자 발송, 2026-07-14 연동): AnalysisService.sendSms(POST
+// /v1/analysis/{id}/send-sms)로 위임한다. 수신자는 서버가 결정(공유 시 전달받은 contact 우선,
+// 없으면 매칭된 고객 연락처)하므로 recipientName/recipientPhone은 API 호출엔 쓰이지 않고
+// 모달 UI 표시용으로만 남아있다. 목록 정렬은 GET /v1/analysis의
 // sortType/sortOrder로 서버에 위임한다(현재 sortType은 consultationDate만 지원). AI 채팅은
 // useDebtReliefAiChat 훅이 AnalysisService.chatHistory/streamChatMessage로 별도 연동한다
 // (DiagnosisDetail 타입에는 대화 내역을 담지 않음).
@@ -75,12 +78,6 @@ import type {
 // ⚠️ reanalyze는 성공 시 status/trackingProcedure/currentProcedureStep을 초기화하고 AI 채팅
 // 이력을 삭제한다(analysis.ts:69-71 참고). DiagnosisFormContent.tsx의 handleAnalyze는 아직
 // 이걸 사용자에게 안내하는 확인 모달이 없다 — 되돌릴 수 없는 부수효과이니 추가를 검토할 것.
-
-const MOCK_LATENCY_MS = 300;
-
-function withMockLatency<T>(value: T): Promise<T> {
-  return new Promise((resolve) => setTimeout(() => resolve(value), MOCK_LATENCY_MS));
-}
 
 // mock 도메인(individual_rehab)과 실 API(individual_rehabilitation)의 절차 코드값이 다르다.
 const PROCEDURE_TO_ANALYSIS: Record<RecommendedProcedure, AnalysisProcedureType> = {
@@ -831,12 +828,21 @@ export const DebtReliefService = {
     };
   },
 
-  // 결과 상세 - 절차 안내 / 고객 안내 문자 발송. 발송 API 미구현 상태의 mock.
-  // 실제 연동 시 SmsService.send처럼 백엔드로 위임하도록 본문만 교체한다.
-  sendGuidanceSms(
-    _projectId: string,
-    _input: SendGuidanceSmsInput
+  // 결과 상세 - 절차 안내 / 고객 안내 문자 발송. diagnosisId 기준으로 서버가 수신자를 결정한다.
+  async sendGuidanceSms(
+    projectId: string,
+    input: SendGuidanceSmsInput
   ): Promise<SendGuidanceSmsResult> {
-    return withMockLatency({ success: true });
+    const response = await AnalysisService.sendSms(Number(input.diagnosisId), projectId, {
+      senderNumberType: input.senderNumberType,
+      senderNumberId: input.senderNumberId,
+      advertisementType: input.advertisementType,
+      serviceName: input.serviceName,
+      title: input.title,
+      content: input.content,
+      scheduledAt: input.scheduledAt,
+      imageUrls: input.imageUrls,
+    });
+    return { success: response.data.result };
   },
 };

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -1,4 +1,5 @@
 import type { ApiSuccess } from "@/types/common";
+import type { SenderNumberType, SmsAdvertisementType } from "@/types/sms";
 
 // Analysis(채무 정리 AI 진단) 도메인 타입
 // Swagger 스펙(POST/GET/PATCH/DELETE /v1/analysis 등) 기준.
@@ -279,6 +280,35 @@ export type AnalysisProcedureChange = {
 
 export type AnalysisProcedureChangesResponse = ApiSuccess<AnalysisProcedureChange>;
 
+/**
+ * POST /v1/analysis/{id}/send-sms
+ * 공유 시 전달받은 연락처(contact)가 있으면 그걸로, 없으면 매칭된 고객 연락처로 발송한다.
+ * 둘 다 없으면 실패(400 BAD_REQUEST).
+ */
+export type AnalysisSendSmsInput = {
+  senderNumberType: SenderNumberType;
+  senderNumberId: number;
+  advertisementType: SmsAdvertisementType;
+  /** 광고성 문자일 경우 필수 */
+  serviceName?: string;
+  /** LMS/MMS에서 사용 */
+  title?: string;
+  content: string;
+  /** ISO 8601, 즉시 발송 시 현재 시간 */
+  scheduledAt: string;
+  imageUrls?: string[];
+};
+
+export type AnalysisSendSmsResult = {
+  smsHistoryId: number;
+  recipientPhoneNumber: string;
+  // Swagger에 enum 미공개, 확인된 값: "contact"(공유 시 전달받은 연락처). 매칭된 고객 연락처로
+  // 발송된 경우의 실제 값은 응답 확인 후 필요시 수정.
+  recipientSource: string;
+};
+
+export type AnalysisSendSmsResponse = ApiSuccess<AnalysisSendSmsResult>;
+
 export type CreateAnalysisResponse = ApiSuccess<AnalysisDetail>;
 export type AnalysisDetailResponse = ApiSuccess<AnalysisDetail>;
 export type UpdateAnalysisResponse = ApiSuccess<AnalysisDetail>;
@@ -372,6 +402,15 @@ export type ConnectableCustomer = {
   name: string;
   contact1: string;
   applicationDate: string;
+  /** 연령대 표시 문자열. API에 있으면 사용, 없으면 "-" */
+  ageRange?: string | null;
+  assignedMemberName?: string | null;
+  assignedTeamName?: string | null;
+  assignedMember?: {
+    id: number;
+    name: string;
+    team?: { id: number; name: string } | null;
+  } | null;
 };
 
 export type ConnectableCustomersQuery = {


### PR DESCRIPTION
고객
- 고객 생성/상세 폼에 성별(PillSelect) 필드 추가, CustomerFormState·API 매핑에 반영

회생파산 허브/폼
- 진단 폼: 채무 현황(금액) 미입력 시 분석 전 안내 모달로 2단계 이동 유도
- 분석하기 버튼: 정적 이미지 배경 대신 회전 보더·스파클 아이콘 애니메이션 적용(globals.css)
- 허브 목록: 사용하지 않는 일괄선택 체크박스 UI 제거
- 진행단계 카드 등 SummaryCards 상하 패딩/정렬 미세 조정
- LinkIcon을 체인 형태 아이콘으로 교체하고 목록/카드에서 크기·색상(#2563EB) 통일

고객연동 모달(CustomerMatchModal)
- 리스트형 UI를 표(연령/전화번호/담당팀/담당자/시간 컬럼) + 모바일 카드형으로 전면 개편
- 페이지당 5건, 스켈레톤 로딩, ESC 닫기, 취소 버튼 등 추가
- ConnectableCustomer 타입에 ageRange/담당팀·담당자 필드 추가

문자 발송
- AnalysisService.sendSms(POST /v1/analysis/{id}/send-sms) 추가, 관련 타입(AnalysisSendSmsInput/Response) 정의
- DebtReliefService.sendGuidanceSms를 mock에서 실 API 연동으로 교체
- SMS 템플릿의 fixedBlock(읽기전용 고정문구) 개념 제거 — 전체 본문을 편집 가능한 initialBody로 통합
- 문자 발송 가능 여부 판단 기준을 customerId 매칭에서 detail.phone 존재 여부로 변경(공유 시 전달받은 연락처도 지원)
- DebtReliefSmsModal의 열림 감지 ref 초기값 버그 수정(첫 오픈 시 템플릿 미반영되는 문제)

기타
- ResultHeader: 고객정보 버튼 노출 조건에서 showAssigneeProfile 체크 제거, 다크모드 텍스트 색상 보정
- SuccessDonut 배경 원 색상을 CSS 변수(--neutral-30)로 전환