### PR TITLE
feat: 진단 허브 요약 카드 상태 분포 개편 및 수임료 환불/중단 전달사항 입력 지원

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -67,7 +67,11 @@
       "Read(//c/Program Files/Google/Chrome/Application/**)",
       "Read(//c/Users/tbrk7/OneDrive/문서/GitHub/talkgate_fe/**)",
       "Bash(python3 *)",
-      "Bash(tasklist //FI \"IMAGENAME eq node.exe\")"
+      "Bash(tasklist //FI \"IMAGENAME eq node.exe\")",
+      "Skill(claude-in-chrome)",
+      "Bash(taskkill //PID 11492 //F)",
+      "Bash(taskkill //PID 14400 //F)",
+      "Bash(tasklist)"
     ]
   }
 }

--- a/src/components/debt-relief/DiagnosisBadges.tsx
+++ b/src/components/debt-relief/DiagnosisBadges.tsx
@@ -9,18 +9,19 @@ import { formatDebtManwonParts } from "@/components/debt-relief/format";
 import { wonToManwon } from "@/components/stats/fee/feeFormat";
 import Tooltip from "@/components/common/Tooltip";
 
-// 상태 배지 색상 — 절차진행중은 피그마 chip 스펙 확인(Secondary-10 #E4EDFF / Secondary-60 #2563EB)
-// 그대로 hex 고정. 반려됨=danger, 계약대기중=warning, 나머지(상담중/검토중/중단)는 neutral.
-// suspended는 의미 확인 전이라 neutral 유지.
-// 다크모드: 피그마 "chip Dark" 스펙(배경 bg-*-10/90, 텍스트 *-80 — Primary만 *-100) 그대로 반영.
-// 그레이 칩은 Dark-60(#b9b9b9)/Dark-20(#333333)이 각각 neutral-60/neutral-25의 다크값과 정확히 일치.
-const STATUS_BADGE_STYLE: Record<AnalysisStatus, string> = {
-  consulting: "bg-neutral-20 text-neutral-70 dark:bg-neutral-60 dark:text-neutral-25",
-  reviewing: "bg-neutral-20 text-neutral-70 dark:bg-neutral-60 dark:text-neutral-25",
+// 상태 배지 색상 — 피그마 chip 스펙 6종 확정(2026-07-20):
+// 상담중=Cyan(#E1F7FF/#2585EB), 검토중=Warning, 반려됨=Error, 계약대기중=Indigo(#E4E3FF/#5856D6),
+// 절차진행중=Secondary, 중단됨=Light gray(#E2E2E2/#595959 = neutral-30/neutral-70).
+// Cyan·Indigo·절차진행중(Secondary-10 #E4EDFF)은 프로젝트 컬러 스케일과 정확히 일치하지 않아 hex 고정.
+// 다크모드: 기존 "chip Dark" 공식(배경 bg-*-10/90, 텍스트 *-80)을 따르되, Cyan·Indigo는 다크 스펙이
+// 없어 같은 공식(배경 90% 불투명, 텍스트를 더 진한 톤으로)으로 추론한 값 — 피그마 다크 스펙 나오면 교체.
+export const STATUS_BADGE_STYLE: Record<AnalysisStatus, string> = {
+  consulting: "bg-[#E1F7FF] text-[#2585EB] dark:bg-[#E1F7FF]/90 dark:text-[#0A5A8C]",
+  reviewing: "bg-warning-10 text-warning-60 dark:bg-warning-10/90 dark:text-warning-80",
   rejected: "bg-danger-10 text-danger-40 dark:bg-danger-10/90 dark:text-danger-80",
-  contract_pending: "bg-warning-10 text-warning-60 dark:bg-warning-10/90 dark:text-warning-80",
+  contract_pending: "bg-[#E4E3FF] text-[#5856D6] dark:bg-[#E4E3FF]/90 dark:text-[#3730A3]",
   in_progress: "bg-[#E4EDFF] text-[#2563EB] dark:bg-secondary-10/90 dark:text-secondary-80",
-  suspended: "bg-neutral-20 text-neutral-70 dark:bg-neutral-60 dark:text-neutral-25",
+  suspended: "bg-neutral-30 text-neutral-70 dark:bg-neutral-60 dark:text-neutral-25",
 };
 
 export function StatusBadge({

--- a/src/components/debt-relief/form/DiagnosisFormContent.tsx
+++ b/src/components/debt-relief/form/DiagnosisFormContent.tsx
@@ -37,6 +37,9 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
   const [loadingForm, setLoadingForm] = useState(isEdit);
   // 수정 모드: 불러온 원본 스냅샷. dirty 비교용. 생성 모드에서는 null.
   const [baselineForm, setBaselineForm] = useState<DiagnosisFormState | null>(null);
+  // 수정 모드: 불러온 진단이 실제 고객 레코드와 매칭되어 있는지. 생성 모드에서는 아래
+  // linkedCustomerId(고객 상세 「추가하기」 진입)로 대체 판단한다.
+  const [existingCustomerId, setExistingCustomerId] = useState<number | null>(null);
 
   // 고객 상세 「추가하기」에서 진입한 경우: customerId를 분석 생성 시 함께 보내 자동 연결한다.
   // 수정 모드에는 적용하지 않는다(고객 매칭은 별도 UI로 이미 처리된 상태).
@@ -46,6 +49,9 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
       ? Number(customerIdParam)
       : undefined;
   const customerNameParam = searchParams.get("customerName");
+
+  // 실제 고객 레코드와 연동된 데이터인지 — 생성: URL로 넘어온 연결 대상, 수정: 이미 매칭된 고객.
+  const isCustomerConnected = isEdit ? existingCustomerId !== null : Boolean(linkedCustomerId);
 
   // 진입 시 1회, 고객명 입력값이 비어있을 때만 쿼리스트링의 고객명으로 채운다.
   useEffect(() => {
@@ -79,10 +85,11 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
     let cancelled = false;
     setLoadingForm(true);
     DebtReliefService.getDiagnosisForm(projectId, diagnosisId)
-      .then((data) => {
+      .then(({ form: data, customerId }) => {
         if (cancelled) return;
         setForm(data);
         setBaselineForm(data);
+        setExistingCustomerId(customerId);
       })
       .catch((error) => {
         if (cancelled) return;
@@ -213,6 +220,7 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
         onAnalyze={handleAnalyze}
         analyzing={analyzing}
         analyzeDisabled={!canAnalyze}
+        isCustomerConnected={isCustomerConnected}
       />
 
       <div className="mx-auto max-w-[1324px] w-full px-0 md:px-6 lg:px-0 md:pt-9 pb-[90px] md:pb-12 flex flex-col md:flex-row gap-5 md:gap-[30px] items-start">
@@ -225,6 +233,7 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
           onAnalyze={handleAnalyze}
           analyzing={analyzing}
           analyzeDisabled={!canAnalyze}
+          isCustomerConnected={isCustomerConnected}
         />
 
         <section className="relative flex-1 w-full surface md:rounded-[14px] shadow-none md:shadow-[0_13px_61px_rgba(169,169,169,0.12)] dark:shadow-none flex flex-col min-h-0 md:min-h-[780px]">

--- a/src/components/debt-relief/form/FormCustomerSummary.tsx
+++ b/src/components/debt-relief/form/FormCustomerSummary.tsx
@@ -3,6 +3,7 @@ import {
   EMPLOYMENT_TYPE_OPTIONS,
   type DiagnosisFormState,
 } from "@/types/debtRelief";
+import LinkIcon from "@/components/icons/LinkIcon";
 
 function optionLabel<T extends string>(
   options: { value: T; label: string }[],
@@ -16,26 +17,31 @@ export function buildCustomerMeta(form: DiagnosisFormState): string {
   const parts = [
     optionLabel(AGE_GROUP_OPTIONS, form.ageGroup),
     form.gender ? (form.gender === "male" ? "남" : "여") : null,
-    optionLabel(EMPLOYMENT_TYPE_OPTIONS, form.employmentType),
+    optionLabel(EMPLOYMENT_TYPE_OPTIONS, form.employmentType) || "무직",
   ].filter(Boolean);
   return parts.join(" · ");
 }
 
 // FormSidebar(데스크톱)와 MobileFormSummaryDrawer(모바일)가 공유하는 고객 요약 행
-export default function FormCustomerSummary({ form }: { form: DiagnosisFormState }) {
+export default function FormCustomerSummary({
+  form,
+  isCustomerConnected = false,
+}: {
+  form: DiagnosisFormState;
+  /** 실제 고객 레코드와 연동된 데이터면 이름 옆에 연동 아이콘을 붙인다. */
+  isCustomerConnected?: boolean;
+}) {
   const meta = buildCustomerMeta(form);
 
   return (
-    <div className="flex items-center gap-3 min-w-0">
-      <div className="w-8 h-8 rounded-full bg-primary-10 text-primary-60 grid place-items-center text-[14px] font-semibold shrink-0">
-        {form.customerName ? form.customerName.charAt(0) : "고"}
-      </div>
-      <div className="min-w-0">
-        <p className="text-[18px] font-bold leading-[21px] text-ink truncate">
+    <div className="min-w-0 text-left">
+      <p className="flex items-center gap-1 min-w-0">
+        <span className="text-[18px] font-bold leading-[21px] text-ink truncate">
           {form.customerName || "고객명"}
-        </p>
-        {meta && <p className="text-[14px] font-medium leading-5 text-neutral-60 truncate">{meta}</p>}
-      </div>
+        </span>
+        {isCustomerConnected && <LinkIcon className="shrink-0 text-[#2563EB]" />}
+      </p>
+      {meta && <p className="text-[14px] font-medium leading-5 text-neutral-60 truncate">{meta}</p>}
     </div>
   );
 }

--- a/src/components/debt-relief/form/FormSidebar.tsx
+++ b/src/components/debt-relief/form/FormSidebar.tsx
@@ -39,6 +39,8 @@ type Props = {
   analyzing: boolean;
   /** 필수값 미충족(생성) / 변경 없음(수정)이면 true — 분석하기 비활성 */
   analyzeDisabled?: boolean;
+  /** 실제 고객 레코드와 연동된 데이터면 이름 옆에 연동 아이콘을 붙인다. */
+  isCustomerConnected?: boolean;
 };
 
 /** Figma: 구분선은 사이드바(286px) 좌우 끝까지 — 콘텐츠 패딩(28px)을 무시하고 bleed */
@@ -60,13 +62,14 @@ export default function FormSidebar({
   onAnalyze,
   analyzing,
   analyzeDisabled = false,
+  isCustomerConnected = false,
 }: Props) {
   const disabled = analyzing || analyzeDisabled;
 
   return (
     <aside className="hidden md:flex md:w-[286px] shrink-0 flex-col surface md:rounded-[14px] pt-6 pb-8 px-[28px] shadow-[0_13px_61px_rgba(169,169,169,0.12)] dark:shadow-none">
       {/* 고객 요약 — 등록 단계에서는 고객 연결을 하지 않는 워크플로로 바뀌어 연결 버튼 제거 */}
-      <FormCustomerSummary form={form} />
+      <FormCustomerSummary form={form} isCustomerConnected={isCustomerConnected} />
 
       {/* Figma: 고객 블록 아래 24px → 풀폭 Divider */}
       <FullBleedDivider className="mt-6" />

--- a/src/components/debt-relief/form/MobileFormSummaryDrawer.tsx
+++ b/src/components/debt-relief/form/MobileFormSummaryDrawer.tsx
@@ -58,6 +58,8 @@ type Props = {
   analyzing: boolean;
   /** 필수값 미충족(생성) / 변경 없음(수정)이면 true — 분석하기 비활성 */
   analyzeDisabled?: boolean;
+  /** 실제 고객 레코드와 연동된 데이터면 이름 옆에 연동 아이콘을 붙인다. */
+  isCustomerConnected?: boolean;
 };
 
 // 전역 헤더 54px + 하단 FormMobileActionBar(~58px, safe-area 포함)를 제외한 높이.
@@ -74,6 +76,7 @@ export default function MobileFormSummaryDrawer({
   onAnalyze,
   analyzing,
   analyzeDisabled = false,
+  isCustomerConnected = false,
 }: Props) {
   const [expanded, setExpanded] = useState(false);
   const step = steps[currentIndex];
@@ -130,7 +133,7 @@ export default function MobileFormSummaryDrawer({
 
       {expanded && (
         <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain bg-neutral-10 px-6 pt-3 pb-5 flex flex-col gap-4">
-          <FormCustomerSummary form={form} />
+          <FormCustomerSummary form={form} isCustomerConnected={isCustomerConnected} />
           <FormFinancialSummary derived={derived} className="bg-card" />
           <FormStepChecklist
             steps={steps}

--- a/src/components/debt-relief/hub/AnalysisShareConfirmModal.tsx
+++ b/src/components/debt-relief/hub/AnalysisShareConfirmModal.tsx
@@ -93,9 +93,12 @@ export default function AnalysisShareConfirmModal({
           공유 전 고객 정보를 다시 한번 확인해 주세요.
         </p>
 
-        <div className="px-7 pb-6 flex flex-col gap-2">
-          <div className="flex items-center gap-4 px-6 py-4 rounded-[12px] border border-neutral-30 bg-card">
-            <div className="min-w-0 flex items-baseline gap-2 flex-wrap">
+        <div className="px-7 pb-6 flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <span className="text-[14px] leading-[17px] font-medium text-neutral-60 tracking-[0.2px]">
+              고객정보
+            </span>
+            <div className="flex items-center gap-2 px-6 py-4 rounded-[12px] border border-neutral-30 bg-card flex-wrap">
               <span className="text-[16px] leading-[19px] font-semibold text-foreground">
                 {displayName}
               </span>
@@ -104,27 +107,47 @@ export default function AnalysisShareConfirmModal({
                   {customerMeta}
                 </span>
               ) : null}
+              {formattedContact ? (
+                <span className="text-[12px] leading-[14px] font-medium text-neutral-60 opacity-80">
+                  {formattedContact}
+                </span>
+              ) : null}
             </div>
           </div>
 
-          <div className="flex items-center gap-4 px-6 py-3 rounded-[8px] bg-neutral-10 dark:bg-neutral-25">
-            <div
-              className="w-5 h-5 rounded-full bg-neutral-20 dark:bg-neutral-30 shrink-0 grid place-items-center text-[11px] font-semibold text-neutral-60"
-              aria-hidden
-            >
-              {displayPartnerName.charAt(0).toUpperCase() || "?"}
-            </div>
-            <span className="text-[14px] leading-5 font-semibold text-foreground truncate min-w-0">
-              {displayPartnerName}
+          <div className="flex flex-col gap-2">
+            <span className="text-[14px] leading-[17px] font-medium text-neutral-60 tracking-[0.2px]">
+              공유받는 프로젝트
             </span>
+            <div className="flex items-center gap-4 px-6 py-3 rounded-[8px] bg-neutral-10 dark:bg-neutral-25">
+              <div
+                className="w-5 h-5 rounded-full bg-neutral-20 dark:bg-neutral-30 shrink-0 grid place-items-center text-[11px] font-semibold text-neutral-60"
+                aria-hidden
+              >
+                {displayPartnerName.charAt(0).toUpperCase() || "?"}
+              </div>
+              <span className="text-[14px] leading-5 font-semibold text-foreground truncate min-w-0">
+                {displayPartnerName}
+              </span>
+            </div>
           </div>
 
-          <div className="px-6 py-3 rounded-[8px] bg-neutral-10 dark:bg-neutral-25 min-h-[84px]">
-            <p className="text-[14px] leading-5 font-medium text-neutral-60 whitespace-pre-line">
-              {formattedContact}
-              {referenceNote ? `\n전달사항 : ${referenceNote}` : ""}
-            </p>
-          </div>
+          {referenceNote ? (
+            <div className="flex flex-col gap-2">
+              <span className="text-[14px] leading-[17px] font-medium text-neutral-60 tracking-[0.2px]">
+                전달사항
+              </span>
+              <div className="flex flex-col gap-2 px-6 py-3 rounded-[8px] bg-neutral-10 dark:bg-neutral-25">
+                <div className="flex items-center gap-2">
+                  <span className="h-3 w-3 rounded-full bg-secondary-20 shrink-0" aria-hidden />
+                  <span className="text-[14px] font-bold leading-5 text-foreground">공유</span>
+                </div>
+                <p className="whitespace-pre-wrap break-words text-[14px] font-medium leading-5 text-neutral-60">
+                  {referenceNote}
+                </p>
+              </div>
+            </div>
+          ) : null}
         </div>
 
         <div className="w-full h-px border-t border-neutral-30 shrink-0" />

--- a/src/components/debt-relief/hub/AnalysisShareContactStep.tsx
+++ b/src/components/debt-relief/hub/AnalysisShareContactStep.tsx
@@ -194,7 +194,9 @@ export default function AnalysisShareContactStep({
             </div>
 
             <div>
-              <label className="block text-[14px] leading-[17px] text-neutral-60 mb-2">전달사항</label>
+              <label className="block text-[14px] leading-[17px] text-neutral-60 mb-2">
+                전달사항 (선택)
+              </label>
               <textarea
                 value={referenceNote}
                 onChange={(e) => setReferenceNote(e.target.value)}

--- a/src/components/debt-relief/hub/DiagnosisFilterModal.tsx
+++ b/src/components/debt-relief/hub/DiagnosisFilterModal.tsx
@@ -22,7 +22,7 @@ const STATUS_ORDER: AnalysisStatus[] = [
 type Props = {
   procedure: RecommendedProcedure | undefined;
   status: AnalysisStatus | undefined;
-  /** 절차별 건수 표시용. 상태(status)는 요약 API에 분포 데이터가 없어 카운트를 표시하지 않는다. */
+  /** 상태별 건수 표시용. 절차(procedure)는 요약 API가 더 이상 분포 데이터를 내려주지 않아 카운트를 표시하지 않는다. */
   summary: DiagnosisHubSummary | null;
   onApply: (next: { procedure: RecommendedProcedure | undefined; status: AnalysisStatus | undefined }) => void;
   onClose: () => void;
@@ -124,7 +124,6 @@ export default function DiagnosisFilterModal({ procedure, status, summary, onApp
             <FilterPill
               key={key}
               label={RECOMMENDED_PROCEDURE_LABEL[key]}
-              count={summary?.procedureDistribution[key]}
               selected={draftProcedure === key}
               onClick={() => toggleProcedure(key)}
             />
@@ -139,6 +138,7 @@ export default function DiagnosisFilterModal({ procedure, status, summary, onApp
             <FilterPill
               key={key}
               label={DIAGNOSIS_STATUS_LABEL[key]}
+              count={summary?.statusDistribution[key]}
               selected={draftStatus === key}
               onClick={() => toggleStatus(key)}
             />

--- a/src/components/debt-relief/hub/DiagnosisMobileCardList.tsx
+++ b/src/components/debt-relief/hub/DiagnosisMobileCardList.tsx
@@ -91,7 +91,7 @@ export default function DiagnosisMobileCardList({
         const customerMeta = formatCustomerMeta(
           item.age,
           item.gender,
-          item.occupation,
+          item.occupation || "무직",
           item.ageGroupLabel
         );
 

--- a/src/components/debt-relief/hub/DiagnosisTable.tsx
+++ b/src/components/debt-relief/hub/DiagnosisTable.tsx
@@ -192,7 +192,7 @@ export default function DiagnosisTable({
               const customerMeta = formatCustomerMeta(
                 item.age,
                 item.gender,
-                undefined,
+                item.occupation || "무직",
                 item.ageGroupLabel
               );
               return (

--- a/src/components/debt-relief/hub/SummaryCards.tsx
+++ b/src/components/debt-relief/hub/SummaryCards.tsx
@@ -2,12 +2,15 @@
 
 import { useEffect, useRef, useState } from "react";
 import {
+  DIAGNOSIS_STATUS_DISTRIBUTION_ORDER,
+  DIAGNOSIS_STATUS_LABEL,
   RECOMMENDED_PROCEDURE_LABEL,
   RECOMMENDED_PROCEDURE_ORDER,
   type DiagnosisHubSummary,
   type RecommendedProcedure,
 } from "@/types/debtRelief";
 import SortIcon from "@/components/common/SortIcon";
+import { STATUS_BADGE_STYLE } from "@/components/debt-relief/DiagnosisBadges";
 
 // 카드 외곽은 공통(304×148 비율)이되, 안쪽 콘텐츠 영역 너비·높이는 카드마다 다름 (피그마 Group 치수).
 const CARD_BASE =
@@ -18,12 +21,6 @@ const CARD_CLASS = `${CARD_BASE} md:py-[22px]`;
 const CARD_PROGRESS_CLASS = `${CARD_BASE} md:pt-[22px] md:pb-3.5`;
 
 const LABEL_CLASS = "text-[13px] md:text-[14px] font-medium leading-[17px] text-neutral-60 shrink-0";
-
-const PROCEDURE_CHIP_STYLE: Record<RecommendedProcedure, string> = {
-  individual_rehab: "bg-primary-10 text-primary-80 dark:bg-primary-10/90 dark:text-primary-100",
-  debt_adjustment: "bg-warning-10 text-warning-60 dark:bg-warning-10/90 dark:text-warning-80",
-  bankruptcy: "bg-danger-10 text-danger-40 dark:bg-danger-10/90 dark:text-danger-80",
-};
 
 // 피그마 모바일: 2×2 그리드 (375px에서도 한 행에 카드 2개)
 const SUMMARY_GRID_CLASS = "grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-5";
@@ -136,11 +133,15 @@ export default function SummaryCards({
 
   if (loading || !summary) return <SummaryCardsSkeleton />;
 
-  const maxProcedureCount = Math.max(
+  const maxStatusCount = Math.max(
     1,
-    ...RECOMMENDED_PROCEDURE_ORDER.map((key) => summary.procedureDistribution[key])
+    ...DIAGNOSIS_STATUS_DISTRIBUTION_ORDER.map((key) => summary.statusDistribution[key])
   );
   const progressSteps = summary.progressStepsByProcedure[selectedProcedure] ?? [];
+  const monthlyPaymentAmountRatio =
+    summary.monthlyPayment.totalAmount > 0
+      ? Math.min(100, Math.max(0, (summary.monthlyPayment.paidAmount / summary.monthlyPayment.totalAmount) * 100))
+      : 0;
 
   return (
     <div className={SUMMARY_GRID_CLASS}>
@@ -149,7 +150,7 @@ export default function SummaryCards({
         <p className={LABEL_CLASS}>총 분석 건수</p>
         <div className="mt-3 md:mt-3 flex flex-col w-fit max-w-full md:h-[62px] md:justify-between">
           <p className="flex items-end gap-1.5">
-            <span className="font-montserrat font-bold text-[22px] md:text-[28px] leading-[34px] tracking-[1px] text-neutral-90">
+            <span className="font-montserrat font-bold text-[22px] md:text-[28px] leading-none tracking-[-0.04em] text-neutral-90">
               {summary.totalAnalysisCount.toLocaleString("ko-KR")}
             </span>
             <span className="text-[14px] md:text-[16px] font-semibold leading-[19px] text-neutral-90 pb-1.5">
@@ -162,48 +163,58 @@ export default function SummaryCards({
         </div>
       </div>
 
-      {/* 평균 성공 가능성 — 안쪽 콘텐츠 ~248×96 (프로그레스 바 풀폭) */}
+      {/* 이번 달 결제 — 안쪽 콘텐츠 ~248×96 (금액/건수 + 프로그레스 바 풀폭) */}
       <div className={CARD_CLASS}>
-        <p className={LABEL_CLASS}>평균 성공 가능성</p>
+        <p className={LABEL_CLASS}>이번 달 결제</p>
         <div className="mt-3 md:mt-[17px] flex flex-col flex-1 min-h-0 w-full md:max-w-[248px]">
-          <p className="flex items-baseline gap-0.5">
-            <span className="font-montserrat font-bold text-[22px] md:text-[28px] leading-[34px] tracking-[1px] text-neutral-90">
-              {summary.averageSuccessProbability}
+          <p className="flex items-end gap-1 flex-wrap">
+            <span className="font-montserrat font-bold text-[22px] md:text-[28px] leading-none tracking-[-0.04em] text-neutral-90">
+              {summary.monthlyPayment.paidAmount.toLocaleString("ko-KR")}
+            </span>
+            <span className="font-montserrat font-medium text-[15px] md:text-[18px] leading-[22px] tracking-[-0.02em] text-neutral-60">
+              /
             </span>
             <span className="font-montserrat font-semibold text-[15px] md:text-[18px] leading-[22px] tracking-[-0.02em] text-neutral-60">
-              /100
+              {summary.monthlyPayment.totalAmount.toLocaleString("ko-KR")}
+            </span>
+            <span className="font-montserrat font-medium text-[15px] md:text-[18px] leading-[22px] tracking-[-0.02em] text-neutral-60">
+              원
             </span>
           </p>
           <div className="mt-auto pt-3 md:pt-0">
             <div className="h-1.5 md:h-2 w-full rounded-[30px] bg-neutral-30 overflow-hidden">
               <div
                 className="h-full rounded-l-[30px] bg-primary-40"
-                style={{
-                  width: `${Math.min(100, Math.max(0, summary.averageSuccessProbability))}%`,
-                }}
+                style={{ width: `${monthlyPaymentAmountRatio}%` }}
               />
             </div>
+            <p className="mt-2 text-[12px] md:text-[13px] font-medium leading-[14px] text-neutral-50">
+              {summary.monthlyPayment.paidCount}/{summary.monthlyPayment.totalCount}건 납부 완료
+            </p>
           </div>
         </div>
       </div>
 
-      {/* 추천 절차 분포 — 안쪽 콘텐츠 ~248×104 (칩+바 행, gap 8) */}
+      {/* 상태 분포 — 안쪽 콘텐츠 ~248×104 (칩+바 행, gap 8, 항목이 많으면 내부 스크롤) */}
       <div className={CARD_CLASS}>
-        <p className={LABEL_CLASS}>추천 절차 분포</p>
-        <div className="mt-2.5 md:mt-3 flex flex-col gap-2 w-full md:max-w-[248px] md:h-[76px]">
-          {RECOMMENDED_PROCEDURE_ORDER.map((key) => {
-            const count = summary.procedureDistribution[key];
+        <p className={LABEL_CLASS}>상태 분포</p>
+        <div
+          className="mt-2.5 md:mt-3 flex flex-col gap-2 overflow-y-auto w-full md:max-w-[248px] md:h-[76px] pr-1"
+          style={{ scrollbarWidth: "thin", scrollbarColor: "#D0D0D0 transparent" }}
+        >
+          {DIAGNOSIS_STATUS_DISTRIBUTION_ORDER.map((key) => {
+            const count = summary.statusDistribution[key];
             return (
               <div key={key} className="flex items-center gap-3 h-5 shrink-0">
                 <span
-                  className={`inline-flex items-center justify-center h-5 px-3 rounded-[30px] text-[12px] font-medium leading-[14px] opacity-80 whitespace-nowrap shrink-0 ${PROCEDURE_CHIP_STYLE[key]}`}
+                  className={`inline-flex items-center justify-center h-5 px-3 rounded-[30px] text-[12px] font-medium leading-[14px] opacity-80 whitespace-nowrap shrink-0 ${STATUS_BADGE_STYLE[key]}`}
                 >
-                  {RECOMMENDED_PROCEDURE_LABEL[key]}
+                  {DIAGNOSIS_STATUS_LABEL[key]}
                 </span>
                 <div className="w-full max-w-[140px] min-w-0 h-1.5 rounded-[30px] bg-neutral-30 overflow-hidden">
                   <div
                     className="h-full rounded-l-[30px] bg-neutral-70"
-                    style={{ width: `${(count / maxProcedureCount) * 100}%` }}
+                    style={{ width: `${(count / maxStatusCount) * 100}%` }}
                   />
                 </div>
                 <span className="text-[12px] font-medium leading-[14px] text-neutral-60 shrink-0 whitespace-nowrap text-right">

--- a/src/components/debt-relief/result/DisclaimerInfoTooltip.tsx
+++ b/src/components/debt-relief/result/DisclaimerInfoTooltip.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+import { useEffect, useId, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+
+// 툴팁 박스와 화면 가장자리 사이 최소 여백
+const VIEWPORT_EDGE_MARGIN = 12;
+// 기본 위치(앵커 대비) — 화면 안에 들어오면 이 값 그대로 사용
+const BASE_OFFSET_PX = 18;
 
 function InfoCircleIcon({ size = 24 }: { size?: number }) {
   return (
@@ -39,7 +44,10 @@ export default function DisclaimerInfoTooltip({
 }) {
   const tooltipId = useId();
   const containerRef = useRef<HTMLSpanElement>(null);
+  const tooltipRef = useRef<HTMLSpanElement>(null);
   const [open, setOpen] = useState(false);
+  // 기본 위치에서 화면 밖으로 나가는 만큼 보정하는 값(px). 0이면 기본 위치 그대로.
+  const [edgeShiftPx, setEdgeShiftPx] = useState(0);
 
   useEffect(() => {
     if (!open) return;
@@ -60,6 +68,31 @@ export default function DisclaimerInfoTooltip({
       document.removeEventListener("pointerdown", handlePointerDown);
       document.removeEventListener("keydown", handleKeyDown);
     };
+  }, [open]);
+
+  // 열릴 때(+리사이즈/회전 시) 툴팁이 뷰포트를 벗어나는지 측정해 좌우로 밀어 넣는다.
+  useLayoutEffect(() => {
+    if (!open) {
+      setEdgeShiftPx(0);
+      return;
+    }
+
+    const measureAndClamp = () => {
+      const tooltipEl = tooltipRef.current;
+      if (!tooltipEl) return;
+      const rect = tooltipEl.getBoundingClientRect();
+      if (rect.right > window.innerWidth - VIEWPORT_EDGE_MARGIN) {
+        setEdgeShiftPx(window.innerWidth - VIEWPORT_EDGE_MARGIN - rect.right);
+      } else if (rect.left < VIEWPORT_EDGE_MARGIN) {
+        setEdgeShiftPx(VIEWPORT_EDGE_MARGIN - rect.left);
+      } else {
+        setEdgeShiftPx(0);
+      }
+    };
+
+    measureAndClamp();
+    window.addEventListener("resize", measureAndClamp);
+    return () => window.removeEventListener("resize", measureAndClamp);
   }, [open]);
 
   return (
@@ -89,24 +122,28 @@ export default function DisclaimerInfoTooltip({
       </button>
 
       <span
+        ref={tooltipRef}
         id={tooltipId}
         role="tooltip"
         aria-hidden={!open}
-        className={`pointer-events-none absolute left-1/2 top-[calc(100%+4px)] z-30 w-[min(325px,calc(100vw-40px))] -translate-x-[18px] transition-opacity duration-150 ${
+        className={`pointer-events-none absolute left-1/2 top-[calc(100%+4px)] z-30 w-[min(325px,calc(100vw-40px))] transition-opacity duration-150 ${
           open ? "opacity-100" : "invisible opacity-0"
         }`}
         style={{
+          transform: `translateX(calc(-${BASE_OFFSET_PX}px + ${edgeShiftPx}px))`,
           filter: open ? "drop-shadow(0px 8px 12px rgba(9, 30, 66, 0.1))" : undefined,
         }}
       >
         {/*
           배경 도형만 opacity 0.7로 묶어 합성 → 포인터/본체 겹쳐도 검은 선 없음.
           텍스트는 별도 레이어로 두어 흐려지지 않게 함.
+          화살표는 박스가 화면 밖으로 안 밀리도록 이동한 만큼(edgeShiftPx) 반대로 보정해
+          아이콘을 계속 가리키도록 유지한다.
         */}
         <span className="absolute inset-0 opacity-70" aria-hidden>
           <span
-            className="absolute left-[8px] top-0 h-[13px] w-5 bg-black"
-            style={{ clipPath: "polygon(50% 0, 100% 100%, 0 100%)" }}
+            className="absolute top-0 h-[13px] w-5 bg-black"
+            style={{ clipPath: "polygon(50% 0, 100% 100%, 0 100%)", left: `${8 - edgeShiftPx}px` }}
           />
           <span className="absolute inset-x-0 bottom-0 top-[12px] rounded-[8px] bg-black" />
         </span>

--- a/src/components/debt-relief/result/FeePaymentInfoModal.tsx
+++ b/src/components/debt-relief/result/FeePaymentInfoModal.tsx
@@ -16,6 +16,7 @@ import type {
 } from "@/types/analysisFeePlan";
 import { wonToManwon } from "@/components/stats/fee/feeFormat";
 import ProcedureSelectModal from "./ProcedureSelectModal";
+import FeePlanActionConfirmModal, { type FeePlanAction } from "./FeePlanActionConfirmModal";
 
 // 총 수임료 입력값(만원)이 이 값을 넘으면 오타(0 개수 실수 등) 가능성을 사용자에게 한 번 확인시킨다.
 const LARGE_TOTAL_AMOUNT_MANWON_THRESHOLD = 5_000;
@@ -201,6 +202,7 @@ export default function FeePaymentInfoModal({
   const [paymentDate, setPaymentDate] = useState<Date | null>(null);
   const [procedureSelectOpen, setProcedureSelectOpen] = useState(false);
   const [procedureSubmitting, setProcedureSubmitting] = useState(false);
+  const [planActionModal, setPlanActionModal] = useState<FeePlanAction | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -288,11 +290,11 @@ export default function FeePaymentInfoModal({
 
     const proceedToConfirm = () => {
       showConfirmModal({
-        title: "결제 조건 확인",
-        headline: "결제 조건을 변경하시겠습니까?",
+        title: "수임료 결제 정보",
+        headline: "결제 정보를 변경합니다.",
         message:
-          "결제 조건을 변경하면 이미 납부(완납/환불) 처리된 회차를 포함해 전체 회차 정보가 새로 계산됩니다.\n계속하시겠습니까?",
-        type: "warning",
+          "이미 납부/환불 처리된 회차를 포함해 전체 회차 정보가 초기화됩니다.\n계속하시겠습니까?",
+        type: "caution",
         confirmText: "확인",
         cancelText: "취소",
         onConfirm: async () => {
@@ -413,38 +415,35 @@ export default function FeePaymentInfoModal({
     });
   };
 
-  const requestPlanAction = (action: "stop" | "refund") => {
+  const requestPlanAction = (action: FeePlanAction) => {
     if (!currentPlan || submitting || currentPlan.status !== "active") return;
+    setPlanActionModal(action);
+  };
+
+  const handlePlanActionConfirm = async (message: string) => {
+    if (!planActionModal) return;
+    const action = planActionModal;
     const isRefund = action === "refund";
-    showConfirmModal({
-      title: isRefund ? "수임료 환불" : "수임료 납부 중단",
-      headline: isRefund ? "수임료 결제를 환불 처리할까요?" : "수임료 납부를 중단할까요?",
-      message: isRefund
-        ? "환불 처리 후에는 납부 정보를 변경할 수 없습니다."
-        : "중단 처리 후에는 남은 회차를 납부 처리할 수 없습니다.",
-      type: "warning",
-      confirmText: isRefund ? "환불" : "중단",
-      cancelText: "취소",
-      onConfirm: async () => {
-        setSubmitting(true);
-        try {
-          const response = isRefund
-            ? await AnalysisService.refundFeePlan(analysisId, projectId)
-            : await AnalysisService.stopFeePlan(analysisId, projectId);
-          updateCurrentPlan(response.data.data);
-        } catch (error) {
-          console.error(`Failed to ${action} analysis fee plan:`, error);
-          showErrorModal({
-            headline: isRefund
-              ? "환불 처리에 실패했습니다."
-              : "납부 중단 처리에 실패했습니다.",
-            description: "잠시 후 다시 시도해주세요.",
-          });
-        } finally {
-          setSubmitting(false);
-        }
-      },
-    });
+    const note = message || null;
+    setSubmitting(true);
+    try {
+      const response = isRefund
+        ? await AnalysisService.refundFeePlan(analysisId, projectId, { message: note })
+        : await AnalysisService.stopFeePlan(analysisId, projectId, { message: note });
+      // fee-plan 응답에는 전달사항이 포함되지 않아(분석 상세의 액션 메시지 히스토리로만 누적) 방금 입력한 값을 로컬로 반영
+      updateCurrentPlan({ ...response.data.data, note });
+      setPlanActionModal(null);
+    } catch (error) {
+      console.error(`Failed to ${action} analysis fee plan:`, error);
+      showErrorModal({
+        headline: isRefund
+          ? "환불 처리에 실패했습니다."
+          : "납부 중단 처리에 실패했습니다.",
+        description: "잠시 후 다시 시도해주세요.",
+      });
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const handleConfirmProcedure = async (procedure: RecommendedProcedure) => {
@@ -627,7 +626,7 @@ export default function FeePaymentInfoModal({
 
               <div className="mt-5 md:mt-6">
                 <label className="block text-[14px] font-medium text-neutral-60 dark:text-[#B9B9B9]">
-                  전달사항(선택사항)
+                  전달사항 (선택)
                 </label>
                 <textarea
                   value={form.note}
@@ -880,6 +879,14 @@ export default function FeePaymentInfoModal({
           submitting={procedureSubmitting}
         />
       ) : null}
+
+      <FeePlanActionConfirmModal
+        open={planActionModal !== null}
+        action={planActionModal ?? "stop"}
+        submitting={submitting}
+        onClose={() => setPlanActionModal(null)}
+        onConfirm={handlePlanActionConfirm}
+      />
     </BaseModal>
   );
 }

--- a/src/components/debt-relief/result/FeePlanActionConfirmModal.tsx
+++ b/src/components/debt-relief/result/FeePlanActionConfirmModal.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type FeePlanAction = "refund" | "stop";
+
+const ACTION_COPY: Record<
+  FeePlanAction,
+  { title: string; message: string; confirmLabel: string }
+> = {
+  refund: {
+    title: "환불 처리",
+    message:
+      "지금까지 납부한 금액은 환불 처리되고\n이미 납부한 회차는 '환불'로 표시되며, 남은 회차는 청구되지 않습니다.",
+    confirmLabel: "환불하기",
+  },
+  stop: {
+    title: "중단 처리",
+    message: "지금까지 납부한 회차는 그대로 유지되고,\n남은 회차는 앞으로 청구되지 않습니다.",
+    confirmLabel: "중단하기",
+  },
+};
+
+type Props = {
+  open: boolean;
+  action: FeePlanAction;
+  submitting?: boolean;
+  onClose: () => void;
+  onConfirm: (message: string) => void;
+};
+
+function CloseIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <path
+        d="M6 18L18 6M6 6L18 18"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default function FeePlanActionConfirmModal({
+  open,
+  action,
+  submitting = false,
+  onClose,
+  onConfirm,
+}: Props) {
+  const [note, setNote] = useState("");
+
+  // 모달을 다시 열 때마다(환불↔중단 전환 포함) 이전 입력이 남아있지 않도록 초기화
+  useEffect(() => {
+    if (open) setNote("");
+  }, [open, action]);
+
+  if (!open) return null;
+
+  const copy = ACTION_COPY[action];
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 bg-black/50 dark:bg-[#000000CC] z-[110]"
+        onClick={() => !submitting && onClose()}
+        aria-hidden
+      />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="fee-plan-action-confirm-title"
+        className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[120] w-[calc(100%-2rem)] max-w-[440px] bg-card dark:bg-neutral-10 rounded-[14px] flex flex-col overflow-hidden"
+        style={{ filter: "drop-shadow(0px 8px 12px rgba(9, 30, 66, 0.1))" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-7 pt-6 pb-[30px] shrink-0">
+          <h2
+            id="fee-plan-action-confirm-title"
+            className="text-[18px] leading-[21px] font-semibold text-foreground"
+          >
+            {copy.title}
+          </h2>
+          <button
+            type="button"
+            onClick={() => !submitting && onClose()}
+            aria-label="닫기"
+            className="cursor-pointer w-6 h-6 grid place-items-center text-neutral-50 hover:opacity-70"
+          >
+            <CloseIcon />
+          </button>
+        </div>
+
+        <p className="px-7 pb-[30px] text-[14px] leading-5 font-medium text-foreground text-center whitespace-pre-line">
+          {copy.message}
+        </p>
+
+        <div className="px-7 pb-6 flex flex-col gap-2">
+          <label
+            htmlFor="fee-plan-action-note"
+            className="text-[14px] leading-[17px] font-medium text-neutral-60 tracking-[0.2px]"
+          >
+            전달사항 (선택)
+          </label>
+          <textarea
+            id="fee-plan-action-note"
+            value={note}
+            onChange={(event) => setNote(event.target.value)}
+            placeholder="전달사항을 입력해 주세요"
+            rows={3}
+            disabled={submitting}
+            className="w-full min-h-[80px] resize-none rounded-[5px] border border-neutral-30 bg-card px-3 py-2 text-[14px] text-foreground outline-none placeholder:text-neutral-50 focus:border-neutral-50 disabled:opacity-60"
+          />
+        </div>
+
+        <div className="w-full h-px border-t border-neutral-30 shrink-0" />
+
+        <div className="flex justify-end items-center gap-3 px-7 py-3 shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="cursor-pointer h-[34px] px-3 rounded-[5px] border border-neutral-30 text-[14px] font-semibold tracking-[-0.02em] text-foreground hover:bg-neutral-10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(note.trim())}
+            disabled={submitting}
+            className="cursor-pointer h-[34px] px-3 rounded-[5px] bg-danger-40 text-white text-[14px] font-semibold tracking-[-0.02em] hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {submitting ? "처리 중..." : copy.confirmLabel}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/debt-relief/result/ResultDetailContent.tsx
+++ b/src/components/debt-relief/result/ResultDetailContent.tsx
@@ -146,7 +146,7 @@ export default function ResultDetailContent({ diagnosisId }: { diagnosisId: stri
     { id: "scores", label: "절차별 성공 가능성" },
     { id: "debt", label: "채무현황" },
     { id: "repayment", label: "예상 변제 계획" },
-    ...(hideCounselMents ? [] : [{ id: "ments", label: "추천 상담 멘트" }]),
+    ...(hideCounselMents ? [] : [{ id: "ments", label: "상담 포인트" }]),
     { id: "guide", label: "절차 안내" },
     { id: "sms", label: "고객 문자 전송" },
   ];
@@ -172,13 +172,19 @@ export default function ResultDetailContent({ diagnosisId }: { diagnosisId: stri
             변호사 공유 건은 AI 분석 추천을 숨기고 overview·scores를 하나의 카드처럼 붙인다. */}
         {hideAiRecommendation ? (
           <div className="flex flex-col gap-0 md:rounded-[14px] md:shadow-[0_13px_61px_rgba(169,169,169,0.12)] dark:md:shadow-none">
-            <SectionCard id="overview" compactTop joined="start" className="max-md:!pt-0">
+            <SectionCard
+              id="overview"
+              compactTop
+              joined="start"
+              joinBottomDivider={detail.messages.length === 0}
+              className="max-md:!pt-0"
+            >
               <ResultHeader detail={detail} projectId={projectId} onCustomerMatchChange={refetch} />
               <div className="hidden md:block mt-0">
                 <ResultAnchorNav sections={sections} activeId={activeId} onNavigate={scrollTo} />
               </div>
               {detail.messages.length > 0 ? (
-                <div className="mt-5 md:mt-6">
+                <div className="mt-3 -mx-6 md:-mx-8 border-t border-neutral-30 px-6 pt-3 md:px-8">
                   <SectionDeliveryMessages messages={detail.messages} />
                 </div>
               ) : null}
@@ -195,7 +201,7 @@ export default function ResultDetailContent({ diagnosisId }: { diagnosisId: stri
                 <ResultAnchorNav sections={sections} activeId={activeId} onNavigate={scrollTo} />
               </div>
               {detail.messages.length > 0 ? (
-                <div className="mt-5 md:mt-6">
+                <div className="mt-3 -mx-6 md:-mx-8 border-t border-neutral-30 px-6 pt-3 md:px-8">
                   <SectionDeliveryMessages messages={detail.messages} />
                 </div>
               ) : null}

--- a/src/components/debt-relief/result/ResultHeader.tsx
+++ b/src/components/debt-relief/result/ResultHeader.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect, useId } from "react";
 import { useRouter } from "next/navigation";
 import { RECOMMENDED_PROCEDURE_LABEL, type DiagnosisDetail } from "@/types/debtRelief";
+import { StatusBadge } from "@/components/debt-relief/DiagnosisBadges";
 import type { AnalysisProcedureType } from "@/types/analysis";
 import { formatContactForDisplay } from "@/utils/format";
 import { AnalysisService } from "@/services/analysis";
@@ -383,6 +384,19 @@ export default function ResultHeader({ detail, projectId, onCustomerMatchChange 
     .filter(Boolean)
     .join(" · ");
 
+  const inProgressStepLabel =
+    detail.status === "in_progress" && detail.procedureGuide.totalSteps > 1
+      ? `${detail.procedureGuide.currentStep}/${detail.procedureGuide.totalSteps}`
+      : undefined;
+
+  const statusBadge = (
+    <StatusBadge
+      status={detail.status}
+      rejectionReason={detail.rejectionReason}
+      stepLabel={inProgressStepLabel}
+    />
+  );
+
   const customerInfoButton = (
     <button
       type="button"
@@ -416,9 +430,12 @@ export default function ResultHeader({ detail, projectId, onCustomerMatchChange 
             </svg>
           </button>
           <div className="min-w-0">
-            <h1 className="text-[16px] font-semibold leading-[19px] tracking-[0.2px] text-black dark:text-neutral-90 truncate">
-              {RECOMMENDED_PROCEDURE_LABEL[detail.trackingProcedure]}
-            </h1>
+            <div className="flex items-center gap-1.5 min-w-0">
+              <h1 className="text-[16px] font-semibold leading-[19px] tracking-[0.2px] text-black dark:text-neutral-90 truncate">
+                {RECOMMENDED_PROCEDURE_LABEL[detail.trackingProcedure]}
+              </h1>
+              {statusBadge}
+            </div>
             <p className="mt-1 text-[16px] font-medium leading-[19px] tracking-[0.2px] text-neutral-60 truncate">
               {customerSummaryLabel}
             </p>
@@ -526,6 +543,7 @@ export default function ResultHeader({ detail, projectId, onCustomerMatchChange 
           <h1 className="text-[24px] font-bold leading-5 text-neutral-90 shrink-0">
             {RECOMMENDED_PROCEDURE_LABEL[detail.trackingProcedure]}
           </h1>
+          {statusBadge}
           <span className="w-px h-4 bg-neutral-60 shrink-0" aria-hidden />
           <span className="text-[18px] font-medium leading-5 text-neutral-60 truncate min-w-0">
             {customerSummaryLabel}

--- a/src/components/debt-relief/result/SectionCard.tsx
+++ b/src/components/debt-relief/result/SectionCard.tsx
@@ -13,6 +13,7 @@ export default function SectionCard({
   compactTop = false,
   topDivider = false,
   joined,
+  joinBottomDivider = false,
 }: {
   id: string;
   title?: string;
@@ -25,9 +26,13 @@ export default function SectionCard({
   // border는 padding 바깥(패딩 박스 경계)에 그려지므로 좌우 패딩과 무관하게 항상 전체 폭으로 표시된다.
   // 데스크톱은 카드 간 gap·shadow로 이미 구분되므로 적용하지 않는다.
   topDivider?: boolean;
-  // 인접 카드와 하나의 섹션처럼 붙일 때: start=상단만 round + 하단 border, end=하단만 round.
+  // 인접 카드와 하나의 섹션처럼 붙일 때: start=상단만 round, end=하단만 round.
   // 그림자는 감싸는 래퍼에 두고, joined 카드 자체는 shadow를 끈다.
   joined?: JoinedEdge;
+  // joined="start"에서만 의미 있음: 하단에 경계 구분선을 그릴지 여부.
+  // 마지막 자식이 이미 자체 테두리로 경계를 표시하는 콘텐츠(예: 전달사항 카드)라면 겹쳐 보이므로
+  // 그 콘텐츠가 없을 때만 켜서, overview·다음 joined 카드 사이가 완전히 비지 않게 한다.
+  joinBottomDivider?: boolean;
 }) {
   const isJoined = joined === "start" || joined === "end";
   const radiusClass = isJoined
@@ -39,7 +44,11 @@ export default function SectionCard({
     ? "shadow-none"
     : "shadow-none md:shadow-[0_13px_61px_rgba(169,169,169,0.12)] dark:md:shadow-none";
   const joinBorderClass =
-    joined === "start" ? "border-b border-neutral-30" : topDivider ? "border-t border-neutral-30 md:border-t-0" : "";
+    joined === "start" && joinBottomDivider
+      ? "border-b border-neutral-30"
+      : topDivider
+        ? "border-t border-neutral-30 md:border-t-0"
+        : "";
   const paddingClass = isJoined
     ? joined === "start"
       ? "pt-3 pb-3 md:pt-7 md:pb-4"

--- a/src/components/debt-relief/result/SectionCounselMents.tsx
+++ b/src/components/debt-relief/result/SectionCounselMents.tsx
@@ -7,6 +7,7 @@ import {
   type DiagnosisDetail,
 } from "@/types/debtRelief";
 import { useDebtReliefAiChat } from "./useDebtReliefAiChat";
+import DisclaimerInfoTooltip from "./DisclaimerInfoTooltip";
 
 function AiSparkleIcon() {
   return (
@@ -100,9 +101,15 @@ export default function SectionCounselMents({
   return (
     <div className="flex flex-col gap-5">
       <div>
-        <h2 className="text-[16px] font-semibold leading-[19px] tracking-[0.2px] text-foreground">
-          추천 상담 멘트
-        </h2>
+        <div className="flex items-center gap-1">
+          <h2 className="inline-flex h-6 items-center text-[16px] font-semibold leading-none tracking-[0.2px] text-foreground">
+            상담 포인트
+          </h2>
+          <DisclaimerInfoTooltip label="상담 포인트 안내">
+            상담을 돕기 위한 참고 자료이며, 최종 상담 내용은{" "}
+            <span className="font-extrabold">고객 상황에 맞게 검토·수정하여 활용해 주세요.</span>
+          </DisclaimerInfoTooltip>
+        </div>
         <div className="mt-3 border-t border-neutral-30" />
       </div>
 

--- a/src/components/debt-relief/result/SectionDeliveryMessages.tsx
+++ b/src/components/debt-relief/result/SectionDeliveryMessages.tsx
@@ -92,7 +92,6 @@ export default function SectionDeliveryMessages({
         </span>
       </button>
 
-      <div className="border-t border-neutral-30" role="separator" />
       <ul
         className={`px-6 py-4 ${
           expanded ? "" : "max-h-[260px] overflow-y-auto"
@@ -135,7 +134,11 @@ export default function SectionDeliveryMessages({
                   <p className="mt-1 whitespace-pre-wrap break-words text-[13px] font-medium leading-4 tracking-[-0.02em] text-neutral-80">
                     {item.message}
                   </p>
-                ) : null}
+                ) : (
+                  <p className="mt-1 text-[13px] font-medium leading-4 tracking-[-0.02em] text-neutral-40 dark:text-neutral-60">
+                    내용 없음
+                  </p>
+                )}
               </div>
             </li>
           );

--- a/src/components/stats/fee/FeeMonthSelector.tsx
+++ b/src/components/stats/fee/FeeMonthSelector.tsx
@@ -41,12 +41,12 @@ export default function FeeMonthSelector({
         </svg>
       </button>
 
-      <div className="flex h-[34px] w-[227px] items-center justify-center rounded-[5px] border border-[#E2E2E2] bg-white px-8 dark:border-neutral-30 dark:bg-neutral-20">
+      <div className="flex h-[34px] w-[227px] justify-center rounded-[5px] border border-[#E2E2E2] bg-white px-8 dark:border-neutral-30 dark:bg-neutral-20">
         <MonthPicker
           value={selectedMonth}
           onChange={handleMonthChange}
           dateFormat="yyyy - MM월"
-          className="h-[34px] w-full cursor-pointer border-none bg-transparent p-0 text-center text-[16px] font-bold leading-[19px] text-[#252525] focus:ring-0 dark:!bg-transparent dark:text-neutral-90"
+          className="!h-full w-full cursor-pointer border-none bg-transparent p-0 text-center text-[16px] font-bold leading-[19px] text-[#252525] focus:ring-0 dark:!bg-transparent dark:text-neutral-90"
         />
       </div>
 

--- a/src/lib/confirmModalEvents.ts
+++ b/src/lib/confirmModalEvents.ts
@@ -1,11 +1,11 @@
-export type ConfirmModalType = "warning" | "info" | "success";
+export type ConfirmModalType = "warning" | "caution" | "info" | "success";
 
 export type ConfirmModalCallbacks = {
   title?: string;
   /** 제목 아래에 표시할 강조 문구. 없으면 message만 표시(기존 동작) */
   headline?: string;
   message?: string;
-  /** warning=붉은 경고삼각형+붉은 headline, info=파란 정보원, success=초록 체크(headline은 기본 스타일) */
+  /** warning=붉은 경고삼각형+붉은 headline, caution=주황 느낌표원+주황 headline, info=파란 정보원, success=초록 체크(headline은 기본 스타일) */
   type?: ConfirmModalType;
   confirmText?: string;
   cancelText?: string | null;

--- a/src/providers/ConfirmModalProvider.tsx
+++ b/src/providers/ConfirmModalProvider.tsx
@@ -154,7 +154,7 @@ export default function ConfirmModalProvider({
             className="absolute inset-0 bg-black/35 dark:bg-[#000000CC]"
             onClick={handleCancel}
           />
-          <div className="relative w-[440px] rounded-[14px] bg-white dark:bg-neutral-10">
+          <div className="relative w-[calc(100%-2rem)] max-w-[440px] rounded-[14px] bg-white dark:bg-neutral-10">
             <div className="px-7 pt-6 pb-[30px]">
               <div
                 className={`flex items-start ${
@@ -216,6 +216,30 @@ export default function ConfirmModalProvider({
                         strokeLinejoin="round"
                       />
                     </svg>
+                  ) : state.type === "caution" ? (
+                    <svg
+                      width="40"
+                      height="40"
+                      viewBox="0 0 40 40"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="text-warning-40 dark:text-warning-20"
+                    >
+                      <circle
+                        cx="20"
+                        cy="20"
+                        r="18"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        d="M20 12V20M20 28H20.01"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
                   ) : state.type === "success" ? (
                     <svg
                       width="40"
@@ -260,6 +284,8 @@ export default function ConfirmModalProvider({
                       className={
                         state.type === "warning"
                           ? "whitespace-pre-line text-[18px] font-semibold leading-[20px] text-[#D83232] dark:text-red-400"
+                          : state.type === "caution"
+                          ? "whitespace-pre-line text-[18px] font-semibold leading-[20px] text-warning-40 dark:text-warning-20"
                           : state.type === "info"
                           ? "whitespace-pre-line text-[18px] font-semibold leading-[20px] text-secondary-80 dark:text-secondary-20"
                           : "whitespace-pre-line text-[18px] font-semibold leading-[20px] text-neutral-90 dark:text-neutral-80"

--- a/src/services/analysis.ts
+++ b/src/services/analysis.ts
@@ -51,7 +51,9 @@ import type {
   PayFeeInstallmentInput,
   PayFeeInstallmentResponse,
   UnpayFeeInstallmentResponse,
+  RefundFeePlanInput,
   RefundFeePlanResponse,
+  StopFeePlanInput,
   StopFeePlanResponse,
 } from "@/types/analysisFeePlan";
 
@@ -374,19 +376,19 @@ export const AnalysisService = {
   },
 
   /** POST /v1/analysis/{id}/fee-plan/refund */
-  refundFeePlan(id: number, projectId: string) {
+  refundFeePlan(id: number, projectId: string, input?: RefundFeePlanInput) {
     return apiClient.post<RefundFeePlanResponse>(
       `/v1/analysis/${id}/fee-plan/refund`,
-      {},
+      { message: input?.message || undefined },
       { headers: { "x-project-id": projectId } }
     );
   },
 
   /** POST /v1/analysis/{id}/fee-plan/stop */
-  stopFeePlan(id: number, projectId: string) {
+  stopFeePlan(id: number, projectId: string, input?: StopFeePlanInput) {
     return apiClient.post<StopFeePlanResponse>(
       `/v1/analysis/${id}/fee-plan/stop`,
-      {},
+      { message: input?.message || undefined },
       { headers: { "x-project-id": projectId } }
     );
   },

--- a/src/services/debtRelief.ts
+++ b/src/services/debtRelief.ts
@@ -55,6 +55,7 @@ import type {
   AnalysisScores,
   AnalysisSortOrder,
   AnalysisSortType,
+  AnalysisStatus,
   AnalysisVehicleValueRange,
   CreateAnalysisInput,
 } from "@/types/analysis";
@@ -590,14 +591,16 @@ export const DebtReliefService = {
     const response = await AnalysisService.summary(projectId);
     const data = response.data.data;
 
-    const procedureDistribution: Record<RecommendedProcedure, number> = {
-      individual_rehab: 0,
-      debt_adjustment: 0,
-      bankruptcy: 0,
+    const statusDistribution: Record<AnalysisStatus, number> = {
+      consulting: 0,
+      reviewing: 0,
+      rejected: 0,
+      contract_pending: 0,
+      in_progress: 0,
+      suspended: 0,
     };
-    for (const item of data.procedureDistribution ?? []) {
-      const key = PROCEDURE_FROM_ANALYSIS[item.procedure];
-      if (key) procedureDistribution[key] = item.count;
+    for (const item of data.statusDistribution ?? []) {
+      statusDistribution[item.status] = item.count;
     }
 
     const progressStepsByProcedure: Record<RecommendedProcedure, { step: number; title?: string; count: number }[]> = {
@@ -620,8 +623,13 @@ export const DebtReliefService = {
     return {
       totalAnalysisCount: data.totalCount,
       thisMonthCount: data.monthlyCount,
-      averageSuccessProbability: Math.round(data.averageSuccessProbability ?? 0),
-      procedureDistribution,
+      monthlyPayment: {
+        totalAmount: data.monthlyPayment?.totalAmount ?? 0,
+        totalCount: data.monthlyPayment?.totalCount ?? 0,
+        paidAmount: data.monthlyPayment?.paidAmount ?? 0,
+        paidCount: data.monthlyPayment?.paidCount ?? 0,
+      },
+      statusDistribution,
       progressStepsByProcedure,
     };
   },
@@ -818,9 +826,15 @@ export const DebtReliefService = {
   },
 
   // 편집(정보 수정) 진입 시 폼에 채울 원본 입력값 조회.
-  async getDiagnosisForm(projectId: string, id: string): Promise<DiagnosisFormState> {
+  async getDiagnosisForm(
+    projectId: string,
+    id: string
+  ): Promise<{ form: DiagnosisFormState; customerId: number | null }> {
     const response = await AnalysisService.detail(Number(id), projectId);
-    return fromAnalysisFormInput(response.data.data.inputData);
+    return {
+      form: fromAnalysisFormInput(response.data.data.inputData),
+      customerId: response.data.data.customerId,
+    };
   },
 
   // 진단 수정(재분석 요청). 성공 시 서버가 status/trackingProcedure/currentProcedureStep을

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -601,8 +601,15 @@ export type BulkDeliverAnalysisResponse = ApiSuccess<BulkDeliverAnalysisResult>;
 // 분석 요약 통계 (GET /v1/analysis/summary)
 // ============================================
 
-export type AnalysisProcedureDistributionItem = {
-  procedure: AnalysisProcedureType;
+export type AnalysisMonthlyPayment = {
+  totalAmount: number; // 이번 달 총 결제 금액 (면제 제외)
+  totalCount: number; // 이번 달 총 결제 건수 (면제 제외)
+  paidAmount: number; // 이번 달 납부 완료 금액
+  paidCount: number; // 이번 달 납부 완료 건수
+};
+
+export type AnalysisStatusDistributionItem = {
+  status: AnalysisStatus;
   count: number;
 };
 
@@ -621,8 +628,8 @@ export type AnalysisStepProgressByProcedure = {
 export type AnalysisSummary = {
   totalCount: number;
   monthlyCount: number;
-  averageSuccessProbability: number;
-  procedureDistribution: AnalysisProcedureDistributionItem[];
+  monthlyPayment: AnalysisMonthlyPayment;
+  statusDistribution: AnalysisStatusDistributionItem[];
   stepProgressByProcedure: AnalysisStepProgressByProcedure[];
 };
 

--- a/src/types/analysisFeePlan.ts
+++ b/src/types/analysisFeePlan.ts
@@ -87,7 +87,17 @@ export type PayFeeInstallmentResponse = ApiSuccess<FeePlan>;
 export type UnpayFeeInstallmentResponse = ApiSuccess<FeePlan>;
 
 /** POST /v1/analysis/{id}/fee-plan/refund */
+export type RefundFeePlanInput = {
+  /** 전달사항 (선택) */
+  message?: string | null;
+};
+
 export type RefundFeePlanResponse = ApiSuccess<FeePlan>;
 
 /** POST /v1/analysis/{id}/fee-plan/stop */
+export type StopFeePlanInput = {
+  /** 전달사항 (선택) */
+  message?: string | null;
+};
+
 export type StopFeePlanResponse = ApiSuccess<FeePlan>;

--- a/src/types/debtRelief.ts
+++ b/src/types/debtRelief.ts
@@ -12,8 +12,8 @@ export const DIAGNOSIS_STATUS_LABEL: Record<AnalysisStatus, string> = {
   rejected: "반려됨",
   contract_pending: "계약대기중",
   in_progress: "절차진행중",
-  // ⚠️ 회의 메모에 없던 상태값 — 정확한 의미(변호사 프로젝트 일시중단 등) 확인 필요, 임시 라벨.
-  suspended: "중단",
+  // ⚠️ 회의 메모에 없던 상태값 — 정확한 의미(변호사 프로젝트 일시중단 등) 확인 필요.
+  suspended: "중단됨",
 };
 
 // 절차안내는 계약 체결(contract_pending) 이후부터 이용 가능.
@@ -126,11 +126,26 @@ export type DiagnosisProgressStepItem = {
 export type DiagnosisHubSummary = {
   totalAnalysisCount: number;
   thisMonthCount: number;
-  averageSuccessProbability: number; // 0~100
-  procedureDistribution: Record<RecommendedProcedure, number>;
+  monthlyPayment: {
+    totalAmount: number; // 이번 달 총 결제 금액 (면제 제외)
+    totalCount: number; // 이번 달 총 결제 건수 (면제 제외)
+    paidAmount: number; // 이번 달 납부 완료 금액
+    paidCount: number; // 이번 달 납부 완료 건수
+  };
+  statusDistribution: Record<AnalysisStatus, number>;
   // 절차별 진행단계 현황 (진행단계 카드에서 셀렉트로 전환해 표시)
   progressStepsByProcedure: Record<RecommendedProcedure, DiagnosisProgressStepItem[]>;
 };
+
+// "상태 분포" 카드 표시 순서 — 반려(rejected)도 포함해 전체 상태 분포를 보여준다.
+export const DIAGNOSIS_STATUS_DISTRIBUTION_ORDER: AnalysisStatus[] = [
+  "in_progress",
+  "consulting",
+  "reviewing",
+  "contract_pending",
+  "suspended",
+  "rejected",
+];
 
 // ── 목록 조회 파라미터 / 응답 ────────────────────────────────
 // GET /v1/analysis의 sortType은 현재 consultationDate만 지원한다.
@@ -486,7 +501,7 @@ export type RepaymentPlan = {
   notes: string[];
 };
 
-// 추천 상담 멘트
+// 상담 포인트
 export type CounselMentCategory = "core" | "concern" | "next";
 export const COUNSEL_MENT_TABS: { key: CounselMentCategory | "all"; label: string }[] = [
   { key: "all", label: "전체" },


### PR DESCRIPTION
- 허브 요약: 추천 절차 분포 → 상태 분포(반려 포함 6종) + 이번 달 결제 카드로 교체
- 상태 배지 색상 6종 확정, 진단 상세 헤더에도 상태 배지 표시
- 수임료 환불/중단 처리에 전달사항(선택) 입력 모달 추가, 확인 모달에 caution 타입 추가
- 진단 폼: 실제 고객 레코드 연동 여부 아이콘 표시, 직업 미입력 시 "무직" 표시
- 분석 공유 확인 모달 레이아웃 정리, 전달사항 라벨 문구 통일
- 전달사항(메시지) 섹션 스타일 정리, 상담 포인트 안내 툴팁 뷰포트 클램핑 추가
- "추천 상담 멘트" 명칭을 "상담 포인트"로 변경