### PR TITLE
feat: 회생·파산 모바일 UI 정비 및 절차/공유/결제 흐름 데이터 정합성 수정

### DIFF
--- a/docs/ANALYSIS_API_QA_CHECKLIST.md
+++ b/docs/ANALYSIS_API_QA_CHECKLIST.md
@@ -1,0 +1,159 @@
+# 회생·파산(Analysis) API 연동 최종 점검 + 브라우저 QA 체크리스트
+
+작성일: 2026-07-21. 목적: 최신 Swagger(Analysis / Analysis Bulk Action / Analysis Fee / Analysis Fee
+Statistics / Analysis Partner)와 현재 코드를 대조해 연동 현황을 확정하고, 배포 전 브라우저에서 직접
+눌러봐야 할 플로우를 체크리스트로 정리한다. 데스크톱 우선(§2) → 모바일은 별도 트랙(§3)으로 뺐다.
+
+---
+
+## 1. API 연동 현황
+
+### Analysis
+
+| 엔드포인트 | 연동 상태 | 사용처 |
+|---|---|---|
+| `POST /v1/analysis` | ✅ | `DebtReliefService.createDiagnosis` → 새 진단 폼 제출 |
+| `GET /v1/analysis` | ✅ | `DebtReliefService` 목록 조회 → 허브 테이블/카드 |
+| `GET /v1/analysis/{id}` | ✅ | `DebtReliefService.getDiagnosisDetail` → 상세 페이지 전체 |
+| `PATCH /v1/analysis/{id}` | ✅ (이번 세션에 상태 게이팅 수정) | `DebtReliefService.updateProcedureProgress` → 절차 전환 + 현재 단계 설정 |
+| `DELETE /v1/analysis/{id}` | ✅ | `ResultDeleteButton.tsx` |
+| `POST /v1/analysis/{id}/accept` | ✅ | `AnalysisReviewBanner.tsx` (변호사) |
+| `GET /v1/analysis/{id}/chat` | ✅ | `useDebtReliefAiChat.ts` |
+| `POST /v1/analysis/{id}/chat/stream` | ✅ | `useDebtReliefAiChat.ts` (SSE) |
+| `GET /v1/analysis/{id}/connectable-customers` | ✅ | `CustomerMatchModal.tsx` |
+| `PATCH /v1/analysis/{id}/customer` | ✅ | `CustomerMatchModal.tsx`, `CustomerCreateMatchModal.tsx` |
+| `DELETE /v1/analysis/{id}/customer` | ✅ | `ResultHeader.tsx`(연결 해제) |
+| `POST /v1/analysis/{id}/deliver` | ⚠️ 선언만, 미사용 | 단건 공유도 `bulkDeliver`로 통일 처리 — 문제 아님(의도적 단순화) |
+| `GET /v1/analysis/{id}/deliveries` | ✅ (제한적) | `ResultDeleteButton.tsx`가 삭제 전 활성 공유 여부 체크용으로만 사용 |
+| `PATCH /v1/analysis/{id}/input` | ✅ | `DebtReliefService.updateDiagnosis`(재분석) |
+| `GET /v1/analysis/{id}/procedure-changes` | ❌ 미사용 | 노출 화면 없음. 상세의 `procedureStepHistory`로 대체되는 듯 보이나 확인 필요 |
+| `POST /v1/analysis/{id}/reject` | ✅ | `AnalysisReviewBanner.tsx` (변호사) |
+| `POST /v1/analysis/{id}/send-sms` | ✅ | `SectionSmsSend.tsx`, `SectionProcedureGuide.tsx`(단계별 문자) |
+| `GET /v1/analysis/procedures` | ❌ 미사용 | 절차 마스터를 클라이언트 하드코딩 값으로 사용 중(실질 문제 아님, 서버값과 다이버전 리스크만 존재) |
+| `GET /v1/analysis/summary` | ✅ | 허브 요약 카드 |
+
+### Analysis Bulk Action
+
+| 엔드포인트 | 상태 | 사용처 |
+|---|---|---|
+| `POST /v1/analysis/bulk-delete` | ✅ | `DebtReliefHubContent.tsx` 일괄삭제 |
+| `POST /v1/analysis/bulk-deliver` | ✅ | `AnalysisShareModal.tsx` (단건/일괄 공유 겸용) |
+
+### Analysis Fee / Fee Statistics
+
+| 엔드포인트 | 상태 | 사용처 |
+|---|---|---|
+| `POST /v1/analysis/{id}/fee-plan` | ✅ | `FeePaymentInfoModal.tsx` |
+| `PATCH /v1/analysis/{id}/fee-plan` | ✅ | `FeePaymentInfoModal.tsx` |
+| `POST .../installments/{id}/pay` | ✅ | `FeePaymentInfoModal.tsx` |
+| `DELETE .../installments/{id}/pay` | ✅ | `FeePaymentInfoModal.tsx`(납부 취소) |
+| `POST .../fee-plan/refund` | ✅ | `FeePaymentInfoModal.tsx` (전달사항 입력 포함) |
+| `POST .../fee-plan/stop` | ✅ | `FeePaymentInfoModal.tsx` (전달사항 입력 포함) |
+| `GET /v1/analysis/fee-statistics/summary` | ✅ | `FeePaymentStatusPanel.tsx` |
+| `GET /v1/analysis/fee-statistics/installments` | ✅ | `FeePaymentStatusPanel.tsx` |
+
+### Analysis Partner
+
+| 엔드포인트 | 상태 |
+|---|---|
+| `GET /v1/analysis-partners` | ✅ 승인된 목록만 조회(`AnalysisShareModal.tsx`) |
+| `POST` / `DELETE /{id}` / `PATCH /{id}/status` / `GET /requests` | 의도적으로 이 프론트엔드 범위 밖 — 별도 외부 admin이 전담 (`services/analysisPartners.ts` 상단 주석 참고) |
+
+---
+
+## 2. 이번 점검에서 새로 발견한 이슈
+
+바로 고칠지는 별도 판단 필요 — 우선 목록만 남긴다.
+
+1. **공유 철회로 이어지지 않는 삭제 안내 (막다른 길)** — 영업점이 공유 중인 진단을 삭제하려 하면
+   `ResultDeleteButton.tsx:85` 에서 "공유를 철회한 뒤 다시 시도해주세요"라고 안내하지만, 실제로 공유를
+   철회하는 버튼/화면이 어디에도 없다(`AnalysisService.revokeDelivery` 미사용). 안내대로 하려 해도 할
+   방법이 없음.
+2. ~~공유 시 참고사항(`referenceNote`) 노출 여부 불확실~~ — **원인 확정 후 수정 완료(이번 세션)**.
+   `POST /v1/analysis/{id}/deliver`·`/bulk-deliver` 실 스펙 확인 결과 참고사항 필드명은
+   `referenceNote`가 아니라 `message`였음. `AnalysisShareModal.tsx`가 `referenceNote`로 보내고 있어
+   백엔드가 인식 못 하고 버렸을 가능성이 높음 — `DeliverAnalysisInput`/`BulkDeliverAnalysisItem`
+   타입과 전송 지점을 `message`로 수정. `DiagnosisDetail.referenceNote`(읽는 쪽)는 실제 상세 응답
+   스키마에 아예 없는 필드라 항상 null이었던 것도 확인됨 — 참고사항은 `messages` 타임라인의 "공유"
+   항목으로만 확인 가능(`SectionDeliveryMessages`). §2-D-6에서 실제로 참고사항 입력 후 타임라인에
+   찍히는지 확인 필요(수정 후 최초 검증).
+3. **모바일 카드 리스트엔 공유 아이콘이 아예 없음** — `DiagnosisMobileCardList.tsx`. 영업점이 모바일에서
+   진단을 공유할 방법이 없다. 모바일 대응 범위(`docs/DEBT_RELIEF_MOBILE_RESPONSIVE_TASKS.md`)에 포함됐는지
+   확인 필요.
+4. **"다시 분석하기"에 확인 모달 없음** — `DiagnosisFormContent.tsx:146` `handleAnalyze`. 재분석 성공 시
+   상태/절차/현재단계가 초기화되고 AI 채팅 이력이 삭제되는 되돌릴 수 없는 부수효과가 있는데, 클릭 전
+   경고가 없다(기존에 알려진 사항 — 별도 지시 전까지 보류 중인 항목이라 여기선 재확인만).
+
+---
+
+## 3. 브라우저 QA 체크리스트 (데스크톱)
+
+**사전 준비**: 영업점(analysis) 프로젝트 1개 + 변호사(lawyer) 프로젝트 1개, 두 프로젝트가 파트너로 연결된
+테스트 계정 필요(`useProjectType`이 서브도메인 선택 프로젝트의 `type`으로 역할을 가른다).
+
+### A. 영업점(analysis) 프로젝트
+
+- [ ] **새 진단 생성**: `/debt-relief/new` 5단계 폼 입력 → AI 진단 실행 → 결과 상세로 이동
+- [ ] **목록/필터**: `/debt-relief` 검색·절차 필터·상태 필터·정렬(상담일)·페이지네이션·표시개수 변경
+- [ ] **AI 채팅**: 상세 페이지에서 AI와 채팅 스트리밍 응답 확인
+- [ ] **고객 매칭**: 미매칭 진단에 기존 고객 연결 / 신규 고객 생성 후 연결 / 연결 해제
+- [ ] **절차 전환(개인회생 ↔ 채무조정 ↔ 파산)**
+  - [ ] `계약대기중` 상태에서 절차 전환 셀렉트가 **눌리는지** (이번 세션에 `stepLocked` 분리 — 셀렉트 자체는 여전히 계약대기중부터 허용)
+  - [ ] 절차 전환 시 "1단계로 초기화" 확인 모달이 뜨고, 확정 후 실제로 1단계로 초기화되는지
+- [ ] **현재 단계로 설정**
+  - [ ] `계약대기중` 상태에서 "현재 단계로 설정" 버튼이 **비활성화**되는지 (이번 세션 수정 사항 — 가장 중요하게 확인)
+  - [ ] `절차진행중` 상태에서는 버튼이 활성화되고 정상 저장되는지
+  - [ ] 현재 단계보다 이전 단계는 버튼이 비활성인지
+- [ ] **단계별 문자 발송**: 절차안내 각 단계의 "문자" 버튼 → 발신번호/템플릿/예약발송까지 실제 발송
+- [ ] **하단 "고객 문자 전송" 섹션**: 필요서류 안내 / 상담일정 안내 / 분석결과 공유 / 직접작성 템플릿 각각 발송
+- [ ] **공유(단건)**: 목록의 공유 아이콘 클릭 → 파트너 선택 → 연락처/참고사항 입력 → 확인 모달 → 발송
+- [ ] **공유(일괄)**: 목록에서 여러 건 체크 → 상단 액션에서 일괄 공유(있다면) 또는 각 건 반복 공유
+- [ ] **재공유 (이번 세션 핵심 수정 사항)**
+  - [ ] 한 번 공유했다가 변호사 쪽에서 반려한 건을 다시 공유 클릭 → **프로젝트 선택 화면 없이 바로 연락처 입력 화면**으로 넘어가는지
+  - [ ] 최종 확인 모달에 원래 공유했던 프로젝트명이 정확히 표시되는지
+  - [ ] 뒤로가기 클릭 시 "닫기" 확인이 뜨는지(프로젝트 선택 화면으로 안 돌아감)
+  - [ ] 한 번도 공유한 적 없는 건은 기존처럼 전체 파트너 목록에서 고르는지
+- [ ] **삭제**: 미공유 건 삭제 정상 동작 / 공유 중인 건은 삭제 시 안내 메시지만 뜨고 실제로는 삭제 불가 확인(§1의 이슈 1 재확인)
+- [ ] **일괄 삭제**: 여러 건 선택 후 일괄 삭제, 공유 중인 건이 섞여 있으면 해당 건은 제외되고 나머지만 삭제되는지
+
+### B. 변호사(lawyer) 프로젝트
+
+- [ ] **목록**: 자체 생성 건 + 영업점이 공유한 건이 함께 보이는지, 담당직원 컬럼 노출
+- [ ] **검토 배너**: 검토중 + 공유중인 건 상세 진입 시 수락/거절 배너 노출
+- [ ] **수락**: 수락 사유(메시지) 입력 → 계약대기중으로 전환
+- [ ] **거절**: 거절 사유 입력 → 반려됨으로 전환, 전달사항 타임라인에 반영
+- [ ] **공유받은 건 읽기 전용 확인**: AI 분석 추천/상담 포인트 섹션 숨김, 절차 전환 셀렉트가 비활성 배지로 표시되는지 (`lawyerReceivedReadOnly`)
+- [ ] **자체 생성 건은 정상 편집 가능**: 변호사 프로젝트가 직접 만든 진단은 절차 전환 등 정상 동작하는지 (공유받은 건과 대비 확인)
+
+### C. 수임료(Fee Plan) — 양쪽 다 필요 시
+
+- [ ] **최초 입력**: `계약대기중` 상태에서만 입력 가능한지, 일괄납부/분할납부 각각 생성
+- [ ] **수정**: 기존 계획 금액/회차 수정
+- [ ] **회차 납부완료 처리 / 취소**: 상태 뱃지·진행률 갱신 확인
+- [ ] **중단**: 사유(전달사항) 입력 후 중단 → 상태가 `중도해지` 등으로 반영, **전달사항 타임라인에 "중단"이 반려와 같은 빨간 점으로 표시되는지 (이번 세션 수정 사항)**
+- [ ] **환불**: 사유 입력 후 환불 → `환불처리` 상태 반영, **전달사항 타임라인에 "환불"이 빨간 점으로 표시되는지 (이번 세션 수정 사항)**
+- [ ] **통계 탭**: `my-settings` 또는 통계 화면에서 수임료 완납/미납/예정/환불 통계가 실제 데이터와 맞는지
+
+### D. 전달사항(메시지 타임라인) — 상세 페이지 상단
+
+- [ ] 공유 시 항목 추가("공유")
+- [ ] 수락/거절 시 항목 추가("수락"/"거절", 사유 메시지 표시)
+- [ ] 수임료 최초입력/수정 시 항목 추가("결제")
+- [ ] 수임료 중단/환불 시 항목 추가("중단"/"환불") — **라벨과 빨간 점 색상 확인 (이번 세션 수정)**
+- [ ] 항목 3건 이상일 때 접기/펼치기 및 내부 스크롤 동작
+- [ ] §1 이슈 2 확인: 공유 항목에 참고사항(referenceNote)이 어떤 형태로든 보이는지, 안 보이면 별도 UI 필요 여부 판단
+
+### E. 회귀 확인 (이번 세션 변경분과 무관하지만 인접 코드)
+
+- [ ] 고객 문자 전송 섹션 연락처 표시 타이포(semibold 14px) 육안 확인
+- [ ] 진단 목록 → 상세 → 목록 뒤로가기 시 필터/검색/페이지 상태 유지
+
+---
+
+## 4. 모바일 — 별도 트랙 (데스크톱 확인 끝난 뒤)
+
+기존 `docs/DEBT_RELIEF_MOBILE_RESPONSIVE_TASKS.md`의 Phase 진행 상황과 함께 아래 항목 추가 확인:
+
+- [ ] `DiagnosisMobileCardList`에 공유 진입점이 없는 것이 의도된 범위인지 디자인 컨펌
+- [ ] 이번 세션에 변경된 절차 전환/현재 단계 설정 게이팅이 모바일 상세 페이지(`SectionProcedureGuide`는 공용 컴포넌트)에서도 동일하게 동작하는지
+- [ ] 재공유 플로우(프로젝트 선택 스킵)가 모바일 폭에서도 레이아웃 깨짐 없이 동작하는지

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -334,46 +334,7 @@
   --color-surface-10: #f8f8f8; /* Light/Light-10 */
 }
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme]) {
-    /* Mirror data-theme="dark" fallback when no explicit theme set */
-    --neutral-0: var(--neutral-dark-0);
-    --neutral-10: var(--neutral-dark-10);
-    --neutral-20: var(--neutral-dark-20);
-    --neutral-25: var(--neutral-dark-25);
-    --neutral-30: var(--neutral-dark-30);
-    --neutral-40: var(--neutral-dark-40);
-    --neutral-50: var(--neutral-dark-50);
-    --neutral-60: var(--neutral-dark-60);
-    --neutral-70: var(--neutral-dark-70);
-    --neutral-80: var(--neutral-dark-80);
-    --neutral-90: var(--neutral-dark-90);
-    --neutral-100: var(--neutral-dark-100);
-
-    --background: var(--neutral-dark-10);
-    --foreground: var(--neutral-dark-80);
-    --card: var(--neutral-dark-0);
-    --muted: var(--neutral-dark-20);
-    --muted-foreground: var(--neutral-dark-60);
-    --border: #444444;
-    --primary: var(--primary-60);
-    --success: var(--primary-80);
-    --warning: var(--warning-40);
-    --danger: var(--danger-40);
-    --color-surface-10: var(--neutral-dark-20);
-    
-    /* Notification unread background (dark mode) */
-    --notification-unread-bg: rgba(214, 250, 232, 0.1);
-    --notification-unread-border: var(--primary-40);
-    
-    /* Customer link modal gradients (dark mode) */
-    --customer-link-create-gradient: linear-gradient(74.9deg, rgba(0, 181, 91, 0.12) 0%, rgba(30, 30, 30, 0.85) 102.03%);
-    --customer-link-existing-gradient: linear-gradient(74.9deg, rgba(77, 130, 243, 0.12) 0%, rgba(30, 30, 30, 0.85) 102.03%);
-    
-    /* Team leader highlight background (dark mode) */
-    --team-leader-highlight-bg: #111111;
-  }
-}
+/* data-theme 미설정 시 :root light 토큰을 그대로 사용 (OS prefers-color-scheme 미반영) */
 
 html, body {
   min-width: 306px; /* 레이아웃이 306px 미만으로 줄어들지 않도록 고정 (뷰포트가 더 좁으면 가로 스크롤) */
@@ -877,6 +838,22 @@ svg path:focus {
 
 @utility animate-toast-slide-up {
   animation: toast-slide-up 0.25s ease-out;
+}
+
+/* 결제정보 유도 말풍선 등장 */
+@keyframes payment-nudge-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@utility animate-payment-nudge-in {
+  animation: payment-nudge-in 0.28s ease-out;
 }
 
 /* Debt-relief analysis loading dots */

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -110,13 +110,9 @@ export default function TestPage() {
     if (!mounted || typeof window === "undefined") return;
 
     const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
-    const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-
-    const initialTheme = storedTheme === "dark" || storedTheme === "light"
-      ? storedTheme
-      : prefersDark
-        ? "dark"
-        : "light";
+    // 저장된 값이 없으면 OS 설정과 무관하게 light를 기본값으로 사용
+    const initialTheme =
+      storedTheme === "dark" || storedTheme === "light" ? storedTheme : "light";
 
     setIsDarkMode(initialTheme === "dark");
   }, [mounted]);

--- a/src/components/debt-relief/DebtReliefHubContent.tsx
+++ b/src/components/debt-relief/DebtReliefHubContent.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useDebtReliefSummary, useDebtReliefList } from "@/hooks/useDebtReliefHub";
+import { useAnalysisProcedureMaster } from "@/hooks/useAnalysisProcedureMaster";
 import { useSelectedProjectId } from "@/hooks/useSelectedProjectId";
 import SummaryCards from "@/components/debt-relief/hub/SummaryCards";
 import DiagnosisFilterTrigger from "@/components/debt-relief/hub/DiagnosisFilterTrigger";
@@ -18,12 +19,14 @@ import { showConfirmModal } from "@/lib/confirmModalEvents";
 import { showErrorModal } from "@/lib/errorModalEvents";
 import { DebtReliefService } from "@/services/debtRelief";
 import { useProjectType } from "@/hooks/useProjectType";
+import type { DiagnosisListItem } from "@/types/debtRelief";
 
 export default function DebtReliefHubContent() {
   const router = useRouter();
   const [projectId] = useSelectedProjectId();
   const { isAnalysis, isLawyer, ready: projectTypeReady } = useProjectType();
   const { summary, loading: summaryLoading } = useDebtReliefSummary();
+  const { stepTitlesByProcedure } = useAnalysisProcedureMaster(projectId);
   const {
     items,
     totalCount,
@@ -51,6 +54,9 @@ export default function DebtReliefHubContent() {
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [shareTargetIds, setShareTargetIds] = useState<string[] | null>(null);
+  // 과거에 공유한 적 있는 건(partnerId 보유)이면 재공유이므로 동일 프로젝트로 고정 —
+  // AnalysisShareModal의 프로젝트 선택 스텝을 건너뛴다.
+  const [shareLockedPartner, setShareLockedPartner] = useState<{ id: number; projectName: string } | null>(null);
 
   // 목록이 새로 로드될 때(필터·검색·정렬·페이지 변경)마다 선택 상태를 초기화한다.
   useEffect(() => {
@@ -84,8 +90,18 @@ export default function DebtReliefHubContent() {
 
   const clearSelection = () => setSelectedIds(new Set());
 
-  const handleShareItem = (id: string) => {
-    setShareTargetIds([id]);
+  const handleShareItem = (item: DiagnosisListItem) => {
+    setShareTargetIds([item.id]);
+    setShareLockedPartner(
+      item.partnerId != null && item.lawyerProjectId != null
+        ? { id: item.partnerId, projectName: item.lawyerProjectName || "프로젝트" }
+        : null
+    );
+  };
+
+  const handleCloseShareModal = () => {
+    setShareTargetIds(null);
+    setShareLockedPartner(null);
   };
 
   const handleDeleteSelected = () => {
@@ -160,10 +176,10 @@ export default function DebtReliefHubContent() {
   };
 
   return (
-    <div className="mx-auto max-w-[1324px] w-full px-0 md:px-6 lg:px-0 md:pt-9 md:pb-12 flex flex-col gap-9">
+    <div className="mx-auto max-w-[1324px] w-full px-0 md:px-6 lg:px-0 md:pt-9 md:pb-12 flex flex-col gap-0 md:gap-9">
       {/* 상단 카드: 제목 + 요약 카드 */}
-      <section className="surface md:rounded-[14px] px-6 md:px-7 py-6 shadow-[0_13px_61px_rgba(169,169,169,0.12)] dark:shadow-none">
-        <div className="flex items-center justify-between gap-4 mb-6">
+      <section className="surface md:rounded-[14px] px-6 md:px-7 py-3 md:py-6 shadow-[0_13px_61px_rgba(169,169,169,0.12)] dark:shadow-none">
+        <div className="flex items-center justify-between gap-4 mb-3 md:mb-6">
           <div className="flex items-center gap-4 flex-wrap min-w-0">
             <h1 className="text-[18px] md:text-[24px] font-bold text-foreground leading-[22px] md:leading-7 truncate">
               회생·파산 진단 목록
@@ -270,6 +286,7 @@ export default function DebtReliefHubContent() {
             allSelectedOnPage={allSelectedOnPage}
             onToggleSelect={toggleSelect}
             onToggleSelectAll={toggleSelectAll}
+            stepTitlesByProcedure={stepTitlesByProcedure}
           />
         </div>
         <div className="md:hidden">
@@ -279,6 +296,7 @@ export default function DebtReliefHubContent() {
             onOpenResult={handleOpenResult}
             selectedIds={selectedIds}
             onToggleSelect={toggleSelect}
+            stepTitlesByProcedure={stepTitlesByProcedure}
           />
         </div>
 
@@ -290,10 +308,11 @@ export default function DebtReliefHubContent() {
       {projectId && (
         <AnalysisShareModal
           open={shareTargetIds !== null}
-          onClose={() => setShareTargetIds(null)}
+          onClose={handleCloseShareModal}
           onSuccess={refetch}
           projectId={projectId}
           analysisIds={shareTargetIds ?? []}
+          lockedPartner={shareLockedPartner}
         />
       )}
     </div>

--- a/src/components/debt-relief/form/DiagnosisFormContent.tsx
+++ b/src/components/debt-relief/form/DiagnosisFormContent.tsx
@@ -203,7 +203,7 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
       case "income":
         return <Step4IncomeExpense form={form} update={update} derived={derived} />;
       case "others":
-        return <Step5Others form={form} update={update} />;
+        return <Step5Others form={form} update={update} onClose={handleClose} />;
     }
   };
 
@@ -237,23 +237,27 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
         />
 
         <section className="relative flex-1 w-full surface md:rounded-[14px] shadow-none md:shadow-[0_13px_61px_rgba(169,169,169,0.12)] dark:shadow-none flex flex-col min-h-0 md:min-h-[780px]">
-          {/* Figma 모바일: X는 폼 카드 우측 상단 — stroke는 foreground 토큰(라이트=#000급 / 다크 반전) */}
-          <button
-            type="button"
-            onClick={handleClose}
-            aria-label="닫기"
-            className="md:hidden absolute top-[8px] right-6 z-10 cursor-pointer w-6 h-6 grid place-items-center text-foreground hover:opacity-70"
-          >
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
-              <path
-                d="M6 18L18 6M6 6L18 18"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </button>
+          {/* Figma 모바일: X는 폼 카드 우측 상단 — stroke는 foreground 토큰(라이트=#000급 / 다크 반전).
+              "기타사항" 스텝은 본문이 토글로 바로 시작해 이 절대배치 X가 어색하게 떠 보여서,
+              그 스텝에서는 숨기고 Step5Others가 자체 타이틀 행에 동일 기능의 X를 대신 렌더링한다. */}
+          {step.key !== "others" && (
+            <button
+              type="button"
+              onClick={handleClose}
+              aria-label="닫기"
+              className="md:hidden absolute top-[8px] right-6 z-10 cursor-pointer w-6 h-6 grid place-items-center text-foreground hover:opacity-70"
+            >
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
+                <path
+                  d="M6 18L18 6M6 6L18 18"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          )}
 
           {/* 헤더 — 모바일에서는 MobileFormSummaryDrawer가 대신하므로 숨김 */}
           {/* Figma: title 24/700, desc 18/500, gap 16, 패딩 28, 구분선은 카드 풀폭 */}

--- a/src/components/debt-relief/form/Step5Others.tsx
+++ b/src/components/debt-relief/form/Step5Others.tsx
@@ -5,6 +5,8 @@ import { FormToggleRow } from "./FormToggle";
 type Props = {
   form: DiagnosisFormState;
   update: <K extends keyof DiagnosisFormState>(key: K, value: DiagnosisFormState[K]) => void;
+  /** 모바일 전용 타이틀 행의 닫기(X) 버튼 — 카드 우상단 절대배치 X와 동일 기능(handleClose) */
+  onClose: () => void;
 };
 
 const DETAIL_INPUT_CLASS =
@@ -17,12 +19,37 @@ const TEXTAREA_CLASS =
  * 기타사항 스텝 — Figma: 토글 행(라벨+스위치) + on 시 상세 인풋, 특이사항 textarea.
  * 카드 보더 없음. 항목 간 gap 24px.
  */
-export default function Step5Others({ form, update }: Props) {
+export default function Step5Others({ form, update, onClose }: Props) {
   return (
     <div>
+      {/* 모바일 전용 — 이 스텝은 다른 스텝과 달리 본문이 토글 목록으로 바로 시작해서, 카드
+          우상단에 절대배치된 닫기(X)만 있으면 첫 항목 옆에 어색하게 떠 보인다. 타이틀 행을
+          만들어 그 오른쪽 끝에 X를 두고, 카드 우상단의 절대배치 X는 이 스텝에서만 숨긴다
+          (DiagnosisFormContent.tsx 참고). */}
+      <div className="md:hidden flex items-center justify-between pb-3 border-b border-neutral-30">
+        <h3 className="text-[16px] font-semibold tracking-[0.2px] text-foreground">
+          소송 및 회생·파산 이력
+        </h3>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="닫기"
+          className="cursor-pointer w-6 h-6 grid place-items-center text-foreground hover:opacity-70 shrink-0"
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
+            <path
+              d="M6 18L18 6M6 6L18 18"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
       <FormSectionTitle>소송 및 회생·파산 이력</FormSectionTitle>
 
-      <div className="mt-0 md:mt-6 flex flex-col gap-6">
+      <div className="mt-3 md:mt-6 flex flex-col gap-6">
         <ToggleDetailRow
           label="이전 개인회생 / 파산 신청 이력 있음"
           checked={form.hasPreviousApplication}

--- a/src/components/debt-relief/hub/AnalysisShareModal.tsx
+++ b/src/components/debt-relief/hub/AnalysisShareModal.tsx
@@ -47,6 +47,9 @@ type Props = {
   customerName?: string;
   /** 고객 매칭된 경우 프리필 연락처 */
   initialContact?: string;
+  /** 과거에 공유한 적 있는 건(재공유): 프로젝트 선택 스텝을 건너뛰고 이 파트너로 고정한다.
+   * 백엔드가 재공유를 동일 프로젝트로만 허용해서(ANALYSIS_ALREADY_SHARED_TO_OTHER_PROJECT), 없으면 최초 공유. */
+  lockedPartner?: { id: number; projectName: string } | null;
 };
 
 const PAGE_LIMIT = 5;
@@ -109,6 +112,7 @@ export default function AnalysisShareModal({
   analysisIds,
   customerName: customerNameProp,
   initialContact: initialContactProp,
+  lockedPartner,
 }: Props) {
   const [step, setStep] = useState<ShareStep>("partners");
   const [partners, setPartners] = useState<AnalysisPartner[]>([]);
@@ -135,7 +139,7 @@ export default function AnalysisShareModal({
   const selectedPartner = partners.find((partner) => partner.id === selectedPartnerId);
 
   const fetchPartners = useCallback(() => {
-    if (!open || !projectId) return;
+    if (!open || !projectId || lockedPartner) return;
 
     setLoading(true);
     AnalysisPartnersService.list(
@@ -155,11 +159,22 @@ export default function AnalysisShareModal({
         });
       })
       .finally(() => setLoading(false));
-  }, [open, projectId, page]);
+  }, [open, projectId, page, lockedPartner]);
 
   useEffect(() => {
     fetchPartners();
   }, [fetchPartners]);
+
+  // 재공유(lockedPartner 있음): 프로젝트 선택 스텝을 건너뛰고 바로 연락처 입력으로 시작
+  useEffect(() => {
+    if (open && lockedPartner) {
+      setSelectedPartnerId(lockedPartner.id);
+      setStep("contact");
+      setContactIndex(0);
+      void ensureMetaLoaded(analysisIds);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, lockedPartner]);
 
   // 닫힐 때 상태 초기화
   useEffect(() => {
@@ -289,6 +304,11 @@ export default function AnalysisShareModal({
       setContactIndex((prev) => prev - 1);
       return;
     }
+    // 재공유(lockedPartner)는 돌아갈 프로젝트 선택 스텝이 없으므로 닫기 확인으로 대체
+    if (lockedPartner) {
+      requestClose();
+      return;
+    }
     setStep("partners");
   };
 
@@ -343,7 +363,8 @@ export default function AnalysisShareModal({
       deliveryItems.push({
         analysisId: Number(id),
         contact: draft.contact,
-        ...(draft.referenceNote ? { referenceNote: draft.referenceNote } : {}),
+        // 실 API 필드명은 message (내부 상태명은 UI 맥락상 referenceNote 유지)
+        ...(draft.referenceNote ? { message: draft.referenceNote } : {}),
       });
     }
 
@@ -559,7 +580,7 @@ export default function AnalysisShareModal({
         ageGroupLabel={currentMeta?.ageGroupLabel}
         gender={currentMeta?.gender}
         occupation={currentMeta?.occupation}
-        partnerName={selectedPartner?.partnerProjectName ?? ""}
+        partnerName={lockedPartner?.projectName ?? selectedPartner?.partnerProjectName ?? ""}
         contact={pendingConfirm?.contact ?? ""}
         referenceNote={pendingConfirm?.referenceNote}
         confirmLabel={isLastContact ? "공유하기" : "다음으로"}

--- a/src/components/debt-relief/hub/DiagnosisMobileCardList.tsx
+++ b/src/components/debt-relief/hub/DiagnosisMobileCardList.tsx
@@ -8,7 +8,11 @@ import {
   resolveFeePlanDisplay,
 } from "@/components/debt-relief/DiagnosisBadges";
 import { formatCustomerMeta } from "@/components/debt-relief/format";
-import { resolveInProgressStepLabel, type DiagnosisListItem } from "@/types/debtRelief";
+import {
+  resolveInProgressStepLabel,
+  type DiagnosisListItem,
+  type ProcedureStepTitlesByProcedure,
+} from "@/types/debtRelief";
 import type { FeePlanSummary } from "@/types/analysisFeePlan";
 
 type Props = {
@@ -17,6 +21,8 @@ type Props = {
   onOpenResult: (id: string) => void;
   selectedIds: Set<string>;
   onToggleSelect: (id: string) => void;
+  /** "진행단계"(n/m) 표시용 절차 마스터 데이터. 생략 시 하드코딩 폴백 사용 */
+  stepTitlesByProcedure?: ProcedureStepTitlesByProcedure;
 };
 
 function CardSkeleton() {
@@ -66,6 +72,7 @@ export default function DiagnosisMobileCardList({
   onOpenResult,
   selectedIds,
   onToggleSelect,
+  stepTitlesByProcedure,
 }: Props) {
   if (loading) {
     return (
@@ -153,7 +160,7 @@ export default function DiagnosisMobileCardList({
                   <StatusBadge
                     status={item.status}
                     rejectionReason={item.rejectionReason}
-                    stepLabel={resolveInProgressStepLabel(item)}
+                    stepLabel={resolveInProgressStepLabel(item, stepTitlesByProcedure)}
                   />
                 </span>
               </div>

--- a/src/components/debt-relief/hub/DiagnosisTable.tsx
+++ b/src/components/debt-relief/hub/DiagnosisTable.tsx
@@ -18,6 +18,7 @@ import {
   resolveInProgressStepLabel,
   type DiagnosisListItem,
   type DiagnosisSortField,
+  type ProcedureStepTitlesByProcedure,
   type SortDirection,
 } from "@/types/debtRelief";
 
@@ -30,13 +31,15 @@ type Props = {
   onOpenResult: (id: string) => void;
   /** 영업점(analysis): 행별 공유 버튼 표시 */
   showShareColumn?: boolean;
-  onShareItem?: (id: string) => void;
+  onShareItem?: (item: DiagnosisListItem) => void;
   /** 변호사(lawyer): 담당직원 컬럼 표시 */
   showAssigneeColumn?: boolean;
   selectedIds: Set<string>;
   allSelectedOnPage: boolean;
   onToggleSelect: (id: string) => void;
   onToggleSelectAll: () => void;
+  /** "진행단계"(n/m) 표시용 절차 마스터 데이터. 생략 시 하드코딩 폴백 사용 */
+  stepTitlesByProcedure?: ProcedureStepTitlesByProcedure;
 };
 
 const HEADER_CELL_BASE =
@@ -127,6 +130,7 @@ export default function DiagnosisTable({
   allSelectedOnPage,
   onToggleSelect,
   onToggleSelectAll,
+  stepTitlesByProcedure,
 }: Props) {
   // 기본 9열(체크~상담일) + 조건부 공유/담당
   const columnCount = 9 + (showShareColumn ? 1 : 0) + (showAssigneeColumn ? 1 : 0);
@@ -251,7 +255,7 @@ export default function DiagnosisTable({
                       <StatusBadge
                         status={item.status}
                         rejectionReason={item.rejectionReason}
-                        stepLabel={resolveInProgressStepLabel(item)}
+                        stepLabel={resolveInProgressStepLabel(item, stepTitlesByProcedure)}
                       />
                     </div>
                   </td>
@@ -272,7 +276,7 @@ export default function DiagnosisTable({
                         type="button"
                         onClick={(e) => {
                           e.stopPropagation();
-                          onShareItem?.(item.id);
+                          onShareItem?.(item);
                         }}
                         className="cursor-pointer inline-flex items-center justify-center w-6 h-6 hover:opacity-80 transition-opacity"
                         aria-label={`${item.customerName} 공유하기`}

--- a/src/components/debt-relief/hub/SummaryCards.tsx
+++ b/src/components/debt-relief/hub/SummaryCards.tsx
@@ -11,19 +11,23 @@ import {
 } from "@/types/debtRelief";
 import SortIcon from "@/components/common/SortIcon";
 import { STATUS_BADGE_STYLE } from "@/components/debt-relief/DiagnosisBadges";
+import { formatWonAsManwonCompact } from "@/components/stats/fee/feeFormat";
 
 // 카드 외곽은 공통(304×148 비율)이되, 안쪽 콘텐츠 영역 너비·높이는 카드마다 다름 (피그마 Group 치수).
+// 모바일(< md)은 카드 높이를 96px로 제한하고 내용이 넘치면 카드 내부에서 세로 스크롤한다.
+// 모바일 라운드는 8px(피그마 375px 프레임 기준), md부터 기존 14px.
 const CARD_BASE =
-  "bg-neutral-10 rounded-[14px] px-4 py-4 md:px-7 md:h-[148px] flex flex-col min-h-0";
-// 1~3번 카드: 상하 패딩 22px
+  "bg-neutral-10 rounded-[8px] px-4 py-3 md:rounded-[14px] md:px-7 max-h-24 overflow-y-auto md:h-[148px] md:max-h-none md:overflow-visible flex flex-col min-h-0";
+// 1~3번 카드: 상하 패딩 22px(데스크톱)
 const CARD_CLASS = `${CARD_BASE} md:py-[22px]`;
 // 진행단계만 하단 패딩 14px — 공통 py를 쓰지 않고 pt/pb를 분리해 다른 카드에 영향 없게 함
 const CARD_PROGRESS_CLASS = `${CARD_BASE} md:pt-[22px] md:pb-3.5`;
 
-const LABEL_CLASS = "text-[13px] md:text-[14px] font-medium leading-[17px] text-neutral-60 shrink-0";
+const LABEL_CLASS = "text-[14px] font-medium leading-[17px] text-neutral-60 shrink-0";
 
-// 피그마 모바일: 2×2 그리드 (375px에서도 한 행에 카드 2개)
-const SUMMARY_GRID_CLASS = "grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-5";
+// 375px 미만은 한 줄에 카드 1개, 375px부터(피그마 모바일 기준) 2×2 — 카드 156px에 맞춰 gap 16px,
+// md부터 4열 + gap 20px.
+const SUMMARY_GRID_CLASS = "grid grid-cols-1 min-[375px]:grid-cols-2 md:grid-cols-4 gap-4 md:gap-5";
 
 function SummaryCardsSkeleton() {
   return (
@@ -70,9 +74,9 @@ function ProgressProcedureSelect({
         onClick={() => setOpen((prev) => !prev)}
         aria-haspopup="listbox"
         aria-expanded={open}
-        className="cursor-pointer inline-flex items-center justify-center gap-2 h-6 min-w-[71px] px-1.5 py-2 rounded border border-neutral-30 bg-card"
+        className="cursor-pointer inline-flex items-center justify-center gap-1 md:gap-2 h-[18px] md:h-6 min-w-[54px] md:min-w-[71px] px-1.5 py-1 md:py-2 rounded border border-neutral-30 bg-card"
       >
-        <span className="text-[12px] font-medium leading-[14px] tracking-[-0.02em] text-foreground whitespace-nowrap">
+        <span className="text-[8px] md:text-[12px] font-medium leading-[10px] md:leading-[14px] tracking-[-0.02em] text-foreground whitespace-nowrap">
           {RECOMMENDED_PROCEDURE_LABEL[value]}
         </span>
         <svg
@@ -148,16 +152,16 @@ export default function SummaryCards({
       {/* 총 분석 건수 — 안쪽 콘텐츠 ~80×96 (좌측 정렬, 좁은 블록) */}
       <div className={CARD_CLASS}>
         <p className={LABEL_CLASS}>총 분석 건수</p>
-        <div className="mt-3 md:mt-3 flex flex-col w-fit max-w-full md:h-[62px] md:justify-between">
+        <div className="mt-2 md:mt-3 flex flex-col w-fit max-w-full md:h-[62px] md:justify-between">
           <p className="flex items-end gap-1.5">
-            <span className="font-montserrat font-bold text-[22px] md:text-[28px] leading-none tracking-[-0.04em] text-neutral-90">
+            <span className="font-montserrat font-bold text-[20px] md:text-[28px] leading-none tracking-[-0.04em] text-neutral-90">
               {summary.totalAnalysisCount.toLocaleString("ko-KR")}
             </span>
-            <span className="text-[14px] md:text-[16px] font-semibold leading-[19px] text-neutral-90 pb-1.5">
+            <span className="text-[12px] md:text-[16px] font-semibold leading-[14px] md:leading-[19px] text-neutral-90 pb-0 md:pb-1.5">
               건
             </span>
           </p>
-          <p className="text-[13px] md:text-[16px] font-medium leading-[19px] text-neutral-60 mt-3 md:mt-0">
+          <p className="text-[12px] md:text-[16px] font-medium leading-[14px] md:leading-[19px] text-neutral-60 mt-2 md:mt-0">
             이번 달 {summary.thisMonthCount}건
           </p>
         </div>
@@ -166,19 +170,20 @@ export default function SummaryCards({
       {/* 이번 달 결제 — 안쪽 콘텐츠 ~248×96 (금액/건수 + 프로그레스 바 풀폭) */}
       <div className={CARD_CLASS}>
         <p className={LABEL_CLASS}>이번 달 결제</p>
-        <div className="mt-3 md:mt-[17px] flex flex-col flex-1 min-h-0 w-full md:max-w-[248px]">
+        <div className="mt-2 md:mt-[17px] flex flex-col flex-1 min-h-0 w-full md:max-w-[248px]">
+          {/* 원 단위 그대로면 자리수가 길어져 모바일에서 줄바꿈이 어색해져 만원 단위(내림)로 축약 표시.
+              "/"가 줄바꿈 시 혼자 남지 않도록 "/ 총액"을 한 덩어리로 묶어서 wrap 단위로 취급 */}
           <p className="flex items-end gap-1 flex-wrap">
-            <span className="font-montserrat font-bold text-[22px] md:text-[28px] leading-none tracking-[-0.04em] text-neutral-90">
-              {summary.monthlyPayment.paidAmount.toLocaleString("ko-KR")}
+            <span className="font-montserrat font-bold text-[20px] md:text-[28px] leading-none tracking-[-0.04em] text-neutral-90">
+              {formatWonAsManwonCompact(summary.monthlyPayment.paidAmount)}
             </span>
-            <span className="font-montserrat font-medium text-[15px] md:text-[18px] leading-[22px] tracking-[-0.02em] text-neutral-60">
-              /
-            </span>
-            <span className="font-montserrat font-semibold text-[15px] md:text-[18px] leading-[22px] tracking-[-0.02em] text-neutral-60">
-              {summary.monthlyPayment.totalAmount.toLocaleString("ko-KR")}
-            </span>
-            <span className="font-montserrat font-medium text-[15px] md:text-[18px] leading-[22px] tracking-[-0.02em] text-neutral-60">
-              원
+            <span className="inline-flex items-end gap-1">
+              <span className="font-montserrat font-medium text-[12px] md:text-[18px] leading-[15px] md:leading-[22px] tracking-[-0.02em] text-neutral-60">
+                /
+              </span>
+              <span className="font-montserrat font-semibold text-[12px] md:text-[18px] leading-[15px] md:leading-[22px] tracking-[-0.02em] text-neutral-60">
+                {formatWonAsManwonCompact(summary.monthlyPayment.totalAmount)}
+              </span>
             </span>
           </p>
           <div className="mt-auto pt-3 md:pt-0">
@@ -188,7 +193,7 @@ export default function SummaryCards({
                 style={{ width: `${monthlyPaymentAmountRatio}%` }}
               />
             </div>
-            <p className="mt-2 text-[12px] md:text-[13px] font-medium leading-[14px] text-neutral-50">
+            <p className="mt-1 md:mt-2 text-[10px] md:text-[13px] font-medium leading-[12px] md:leading-[14px] text-neutral-50">
               {summary.monthlyPayment.paidCount}/{summary.monthlyPayment.totalCount}건 납부 완료
             </p>
           </div>
@@ -199,25 +204,25 @@ export default function SummaryCards({
       <div className={CARD_CLASS}>
         <p className={LABEL_CLASS}>상태 분포</p>
         <div
-          className="mt-2.5 md:mt-3 flex flex-col gap-2 overflow-y-auto w-full md:max-w-[248px] md:h-[76px] pr-1"
+          className="mt-1 md:mt-3 flex flex-col gap-1 md:gap-2 overflow-y-auto w-full md:max-w-[248px] md:h-[76px] pr-1"
           style={{ scrollbarWidth: "thin", scrollbarColor: "#D0D0D0 transparent" }}
         >
           {DIAGNOSIS_STATUS_DISTRIBUTION_ORDER.map((key) => {
             const count = summary.statusDistribution[key];
             return (
-              <div key={key} className="flex items-center gap-3 h-5 shrink-0">
+              <div key={key} className="flex items-center gap-3 h-[14px] md:h-5 shrink-0">
                 <span
-                  className={`inline-flex items-center justify-center h-5 px-3 rounded-[30px] text-[12px] font-medium leading-[14px] opacity-80 whitespace-nowrap shrink-0 ${STATUS_BADGE_STYLE[key]}`}
+                  className={`inline-flex items-center justify-center h-[14px] px-1 rounded-[5px] text-[8px] leading-[10px] md:h-5 md:px-3 md:rounded-[30px] md:text-[12px] md:leading-[14px] font-medium opacity-80 whitespace-nowrap shrink-0 ${STATUS_BADGE_STYLE[key]}`}
                 >
                   {DIAGNOSIS_STATUS_LABEL[key]}
                 </span>
-                <div className="w-full max-w-[140px] min-w-0 h-1.5 rounded-[30px] bg-neutral-30 overflow-hidden">
+                <div className="w-full max-w-[140px] min-w-0 h-1 md:h-1.5 rounded-[30px] bg-neutral-30 overflow-hidden">
                   <div
                     className="h-full rounded-l-[30px] bg-neutral-70"
                     style={{ width: `${(count / maxStatusCount) * 100}%` }}
                   />
                 </div>
-                <span className="text-[12px] font-medium leading-[14px] text-neutral-60 shrink-0 whitespace-nowrap text-right">
+                <span className="text-[10px] md:text-[12px] font-medium leading-[12px] md:leading-[14px] text-neutral-60 shrink-0 whitespace-nowrap text-right">
                   {count}건
                 </span>
               </div>
@@ -228,34 +233,34 @@ export default function SummaryCards({
 
       {/* 진행단계 — 절차 셀렉트 + 스크롤 목록 (모바일·데스크톱 모두 높이 제한 후 내부 스크롤) */}
       <div className={`${CARD_PROGRESS_CLASS} min-h-0`}>
-        <div className="flex items-start justify-between gap-2 shrink-0">
-          <div className="flex items-start gap-0.5 min-w-0">
+        <div className="flex items-center justify-between gap-2 shrink-0">
+          <div className="flex items-center gap-0.5 min-w-0">
             <p className={LABEL_CLASS}>진행단계</p>
-            <SortIcon state="none" className="-ml-0.5 -mt-0.5 shrink-0" />
+            <SortIcon state="none" className="-ml-0.5 shrink-0" />
           </div>
           <ProgressProcedureSelect value={selectedProcedure} onChange={setSelectedProcedure} />
         </div>
         <div
-          className="mt-2.5 md:mt-3 flex flex-col gap-3 overflow-y-auto w-full md:max-w-[248px] h-[76px] pr-1"
+          className="mt-1 md:mt-3 flex flex-col gap-1 md:gap-3 overflow-y-auto w-full md:max-w-[248px] h-[76px] pr-1"
           style={{ scrollbarWidth: "thin", scrollbarColor: "#D0D0D0 transparent" }}
         >
           {progressSteps.length === 0 ? (
-            <p className="text-[12px] font-medium leading-[14px] text-neutral-50">
+            <p className="text-[10px] md:text-[12px] font-medium leading-[12px] md:leading-[14px] text-neutral-50">
               표시할 진행단계가 없습니다.
             </p>
           ) : (
             progressSteps.map(({ step, title, count }) => (
               <div
                 key={`${selectedProcedure}-${step}-${title ?? ""}`}
-                className="flex items-center justify-between h-4 shrink-0 gap-2"
+                className="flex items-center justify-between h-[14px] md:h-4 shrink-0 gap-2"
               >
                 <span className="inline-flex items-center gap-2 min-w-0">
-                  <span className="w-2 h-2 rounded-full shrink-0 bg-secondary-20" aria-hidden />
-                  <span className="text-[13px] md:text-[14px] font-medium leading-4 tracking-[-0.02em] text-neutral-90 truncate">
+                  <span className="w-1.5 h-1.5 md:w-2 md:h-2 rounded-full shrink-0 bg-secondary-20" aria-hidden />
+                  <span className="text-[10px] md:text-[14px] font-medium leading-[12px] md:leading-4 tracking-[-0.02em] text-neutral-90 truncate">
                     {title ? `${step}단계. ${title}` : `${step}단계`}
                   </span>
                 </span>
-                <span className="text-[12px] font-medium leading-[14px] text-neutral-60 shrink-0 text-right">
+                <span className="text-[10px] md:text-[12px] font-medium leading-[12px] md:leading-[14px] text-neutral-60 shrink-0 text-right">
                   {count}건
                 </span>
               </div>

--- a/src/components/debt-relief/result/AnalysisReviewBanner.tsx
+++ b/src/components/debt-relief/result/AnalysisReviewBanner.tsx
@@ -3,8 +3,9 @@
 import { useState } from "react";
 import { DebtReliefService } from "@/services/debtRelief";
 import { showErrorModal } from "@/providers/ErrorFeedbackModalProvider";
-import type { DiagnosisDetail } from "@/types/debtRelief";
+import type { DiagnosisDetail, RecommendedProcedure } from "@/types/debtRelief";
 import AnalysisReviewDecisionModal from "./AnalysisReviewDecisionModal";
+import ProcedureSelectModal from "./ProcedureSelectModal";
 
 type Props = {
   detail: DiagnosisDetail;
@@ -20,6 +21,8 @@ const ACTION_BTN_BASE =
 export default function AnalysisReviewBanner({ detail, projectId, onDecided }: Props) {
   const [decisionMode, setDecisionMode] = useState<"accept" | "reject" | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [procedureSelectOpen, setProcedureSelectOpen] = useState(false);
+  const [procedureSubmitting, setProcedureSubmitting] = useState(false);
 
   const closeDecisionModal = () => {
     if (submitting) return;
@@ -32,11 +35,22 @@ export default function AnalysisReviewBanner({ detail, projectId, onDecided }: P
     try {
       if (decisionMode === "accept") {
         await DebtReliefService.acceptSharedAnalysis(projectId, detail.id, message || undefined);
+        setDecisionMode(null);
+        // 결제 정보가 이미 입력돼 있는 건은 수락 직후 추적할 절차를 바로 정할 수 있게 한다.
+        // onDecided(refetch)는 상태가 바뀌어 이 배너 자체가 사라지게 만들므로, 절차 선택
+        // 모달이 뜨는 동안은 미루고 모달이 닫힐 때(선택 완료/취소) 호출한다.
+        // defaultProcedure가 없으면(procedureScores 없음) 모달이 렌더링되지 않아 onDecided가
+        // 영영 호출되지 않는 채로 멈추므로, 그 경우엔 절차 선택을 건너뛴다.
+        if (detail.feePlan && defaultProcedure) {
+          setProcedureSelectOpen(true);
+        } else {
+          onDecided();
+        }
       } else {
         await DebtReliefService.rejectSharedAnalysis(projectId, detail.id, message || undefined);
+        setDecisionMode(null);
+        onDecided();
       }
-      setDecisionMode(null);
-      onDecided();
     } catch (error) {
       console.error(`Failed to ${decisionMode} shared analysis:`, error);
       showErrorModal({
@@ -46,6 +60,36 @@ export default function AnalysisReviewBanner({ detail, projectId, onDecided }: P
       });
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const defaultProcedure =
+    detail.procedureScores.find((score) => score.recommended)?.procedure ??
+    detail.procedureScores[0]?.procedure;
+
+  const closeProcedureSelect = () => {
+    if (procedureSubmitting) return;
+    setProcedureSelectOpen(false);
+    onDecided();
+  };
+
+  const handleConfirmProcedure = async (procedure: RecommendedProcedure) => {
+    if (!projectId) return;
+    setProcedureSubmitting(true);
+    try {
+      await DebtReliefService.updateProcedureProgress(projectId, detail.id, {
+        trackingProcedure: procedure,
+      });
+      setProcedureSelectOpen(false);
+      onDecided();
+    } catch (error) {
+      console.error("Failed to set tracking procedure:", error);
+      showErrorModal({
+        headline: "진행 절차를 설정하지 못했습니다.",
+        description: "잠시 후 다시 시도해주세요.",
+      });
+    } finally {
+      setProcedureSubmitting(false);
     }
   };
 
@@ -87,6 +131,17 @@ export default function AnalysisReviewBanner({ detail, projectId, onDecided }: P
         onClose={closeDecisionModal}
         onSubmit={handleSubmitDecision}
       />
+
+      {defaultProcedure ? (
+        <ProcedureSelectModal
+          open={procedureSelectOpen}
+          onClose={closeProcedureSelect}
+          onConfirm={handleConfirmProcedure}
+          procedureScores={detail.procedureScores}
+          defaultProcedure={defaultProcedure}
+          submitting={procedureSubmitting}
+        />
+      ) : null}
     </>
   );
 }

--- a/src/components/debt-relief/result/CustomerCreateMatchModal.tsx
+++ b/src/components/debt-relief/result/CustomerCreateMatchModal.tsx
@@ -216,7 +216,7 @@ export default function CustomerCreateMatchModal({
           </div>
 
           <div>
-            <label className="block text-[14px] leading-[17px] text-neutral-60 mb-2">참고사항</label>
+            <label className="block text-[14px] leading-[17px] text-neutral-60 mb-2">전달사항 (선택)</label>
             <textarea
               value={specialNotes}
               onChange={(e) => setSpecialNotes(e.target.value)}

--- a/src/components/debt-relief/result/DeliveryMessagesPopup.tsx
+++ b/src/components/debt-relief/result/DeliveryMessagesPopup.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { DiagnosisMessage } from "@/types/debtRelief";
+import { DeliveryMessageTimeline } from "./SectionDeliveryMessages";
+
+function CloseIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden>
+      <path
+        d="M5 5L15 15M5 15L15 5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+// 모바일 전용 — AI 분석 추천 영역 위에 떠서 그 영역을 덮는 전달사항 팝업.
+// 데스크톱 접이식 섹션(SectionDeliveryMessages)과 달리 펼치기/접기 없이 항상 내부 스크롤로 표시한다.
+export default function DeliveryMessagesPopup({
+  messages,
+  onClose,
+}: {
+  messages: DiagnosisMessage[];
+  onClose: () => void;
+}) {
+  return (
+    <div className="md:hidden absolute inset-x-0 top-0 z-20 rounded-[12px] border border-secondary-20 bg-card shadow-[0_13px_61px_rgba(169,169,169,0.25)] dark:border-secondary-40 dark:shadow-none">
+      <div className="flex items-center justify-between px-6 py-4">
+        <h3 className="text-[16px] font-semibold leading-[19px] tracking-[-0.02em] text-foreground">
+          전달사항
+        </h3>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="전달사항 닫기"
+          className="cursor-pointer grid h-6 w-6 place-items-center text-neutral-50 dark:text-neutral-60"
+        >
+          <CloseIcon />
+        </button>
+      </div>
+      <div className="max-h-[320px] overflow-y-auto px-6 pb-4">
+        <DeliveryMessageTimeline messages={messages} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/debt-relief/result/DisclaimerInfoTooltip.tsx
+++ b/src/components/debt-relief/result/DisclaimerInfoTooltip.tsx
@@ -37,10 +37,18 @@ export default function DisclaimerInfoTooltip({
   children,
   iconSize = 24,
   label = "안내",
+  maxWidthPx = 325,
+  fitContent = false,
 }: {
   children: ReactNode;
   iconSize?: number;
   label?: string;
+  /** 말풍선 최대 너비(px). 뷰포트가 좁으면 calc(100vw-40px)로 자동 축소된다. */
+  maxWidthPx?: number;
+  /** true면 maxWidthPx는 상한선으로만 쓰고, 실제 너비는 내용(줄바꿈 포함)에 맞춰 줄어든다.
+   * children에 <br/>로 줄바꿈을 직접 지정한 경우 사용 — 폰트 로딩/폭 변화에 관계없이 항상
+   * 지정한 줄 수로 렌더된다. false(기본)면 항상 maxWidthPx로 고정해 자연스러운 문단 줄바꿈을 유도한다. */
+  fitContent?: boolean;
 }) {
   const tooltipId = useId();
   const containerRef = useRef<HTMLSpanElement>(null);
@@ -126,10 +134,12 @@ export default function DisclaimerInfoTooltip({
         id={tooltipId}
         role="tooltip"
         aria-hidden={!open}
-        className={`pointer-events-none absolute left-1/2 top-[calc(100%+4px)] z-30 w-[min(325px,calc(100vw-40px))] transition-opacity duration-150 ${
+        className={`pointer-events-none absolute left-1/2 top-[calc(100%+4px)] z-30 transition-opacity duration-150 ${
           open ? "opacity-100" : "invisible opacity-0"
         }`}
         style={{
+          width: fitContent ? "fit-content" : `min(${maxWidthPx}px, calc(100vw - 40px))`,
+          maxWidth: `min(${maxWidthPx}px, calc(100vw - 40px))`,
           transform: `translateX(calc(-${BASE_OFFSET_PX}px + ${edgeShiftPx}px))`,
           filter: open ? "drop-shadow(0px 8px 12px rgba(9, 30, 66, 0.1))" : undefined,
         }}

--- a/src/components/debt-relief/result/FeePaymentInfoModal.tsx
+++ b/src/components/debt-relief/result/FeePaymentInfoModal.tsx
@@ -288,7 +288,57 @@ export default function FeePaymentInfoModal({
       return;
     }
 
+    const saveFeePlan = async () => {
+      setSubmitting(true);
+      const wasCreate = !currentPlan;
+      try {
+        const firstPaymentDate = toApiDate(form.firstPaymentDate!);
+        const note = form.note.trim() || null;
+        const totalAmountWon = manwonToWon(totalAmount);
+        const response = currentPlan
+          ? await AnalysisService.updateFeePlan(analysisId, {
+              projectId,
+              totalAmount: totalAmountWon,
+              paymentType: form.paymentType,
+              installmentCount,
+              firstPaymentDate,
+              message: note,
+            })
+          : await AnalysisService.createFeePlan(analysisId, {
+              projectId,
+              totalAmount: totalAmountWon,
+              paymentType: form.paymentType,
+              installmentCount,
+              firstPaymentDate,
+              trackingProcedure,
+              message: note,
+            });
+        // fee-plan 저장 응답에는 전달사항이 포함되지 않아(분석 상세의 액션 메시지 히스토리로만 누적) 방금 입력한 값을 로컬로 반영
+        updateCurrentPlan({ ...response.data.data, note });
+        // 최초 결제 정보 생성 시에만 진행할 절차를 명시적으로 고르게 한다 — 이미 절차를
+        // 추적 중인 건(조건수정)은 절차를 바꾸는 액션이 아니므로 다시 묻지 않는다.
+        // defaultProcedure가 없으면(procedureScores 없음) 모달이 렌더링되지 않아 닫을 방법이
+        // 없는 채로 멈추므로, 그 경우엔 절차 선택을 건너뛴다.
+        if (wasCreate && defaultProcedure) {
+          setProcedureSelectOpen(true);
+        }
+      } catch (error) {
+        console.error("Failed to save analysis fee plan:", error);
+        showErrorModal({
+          headline: "수임료 결제 조건을 저장하지 못했습니다.",
+          description: "잠시 후 다시 시도해주세요.",
+        });
+      } finally {
+        setSubmitting(false);
+      }
+    };
+
     const proceedToConfirm = () => {
+      // 최초 결제 정보 생성 시에는 초기화될 기존 회차 정보가 없으므로 변경 확인 모달을 건너뛴다.
+      if (!currentPlan) {
+        void saveFeePlan();
+        return;
+      }
       showConfirmModal({
         title: "수임료 결제 정보",
         headline: "결제 정보를 변경합니다.",
@@ -297,48 +347,7 @@ export default function FeePaymentInfoModal({
         type: "caution",
         confirmText: "확인",
         cancelText: "취소",
-        onConfirm: async () => {
-          setSubmitting(true);
-          const wasCreate = !currentPlan;
-          try {
-            const firstPaymentDate = toApiDate(form.firstPaymentDate!);
-            const note = form.note.trim() || null;
-            const totalAmountWon = manwonToWon(totalAmount);
-            const response = currentPlan
-              ? await AnalysisService.updateFeePlan(analysisId, {
-                  projectId,
-                  totalAmount: totalAmountWon,
-                  paymentType: form.paymentType,
-                  installmentCount,
-                  firstPaymentDate,
-                  message: note,
-                })
-              : await AnalysisService.createFeePlan(analysisId, {
-                  projectId,
-                  totalAmount: totalAmountWon,
-                  paymentType: form.paymentType,
-                  installmentCount,
-                  firstPaymentDate,
-                  trackingProcedure,
-                  message: note,
-                });
-            // fee-plan 저장 응답에는 전달사항이 포함되지 않아(분석 상세의 액션 메시지 히스토리로만 누적) 방금 입력한 값을 로컬로 반영
-            updateCurrentPlan({ ...response.data.data, note });
-            // 최초 결제 정보 생성 시에만 진행할 절차를 명시적으로 고르게 한다 — 이미 절차를
-            // 추적 중인 건(조건수정)은 절차를 바꾸는 액션이 아니므로 다시 묻지 않는다.
-            if (wasCreate) {
-              setProcedureSelectOpen(true);
-            }
-          } catch (error) {
-            console.error("Failed to save analysis fee plan:", error);
-            showErrorModal({
-              headline: "수임료 결제 조건을 저장하지 못했습니다.",
-              description: "잠시 후 다시 시도해주세요.",
-            });
-          } finally {
-            setSubmitting(false);
-          }
-        },
+        onConfirm: saveFeePlan,
       });
     };
 
@@ -474,6 +483,25 @@ export default function FeePaymentInfoModal({
     currentPlan && currentPlan.totalAmount > 0
       ? Math.min(100, Math.max(0, (paidAmount / currentPlan.totalAmount) * 100))
       : 0;
+
+  // 최초 결제 정보 생성 후 진행 절차 선택 모달이 열려 있는 동안에는 본 모달을
+  // 겹쳐서 노출하지 않고, 절차 선택 → 결제 정보 상세 순으로 순차 노출한다.
+  if (procedureSelectOpen) {
+    return (
+      <>
+        {defaultProcedure ? (
+          <ProcedureSelectModal
+            open={procedureSelectOpen}
+            onClose={() => setProcedureSelectOpen(false)}
+            onConfirm={handleConfirmProcedure}
+            procedureScores={procedureScores}
+            defaultProcedure={defaultProcedure}
+            submitting={procedureSubmitting}
+          />
+        ) : null}
+      </>
+    );
+  }
 
   return (
     <BaseModal
@@ -776,52 +804,61 @@ export default function FeePaymentInfoModal({
                     <InstallmentStatus installment={installment} />
 
                     <div className="ml-auto flex min-w-0 items-center gap-2">
-                      {editing ? (
-                        <>
-                          <div className="w-[190px] max-w-[45vw]">
-                            <div className="relative">
-                              <DatePicker
-                                value={paymentDate}
-                                onChange={setPaymentDate}
-                                disabled={submitting}
-                                className="!h-[38px] !pr-10"
-                                dateFormat="yyyy. MM. dd"
-                              />
-                              <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-neutral-50">
-                                <CalendarIcon />
-                              </span>
+                      {installment.status === "scheduled" || editing ? (
+                        <div className="relative flex items-center gap-2">
+                          {/* 날짜 입력 영역은 항상 자리(폭)를 차지하고, 편집 중이 아닐 때는 안 보이게만
+                              처리한다 — 체크해서 데이트피커가 나타나도 행/모달 너비가 변하지 않도록. */}
+                          <div
+                            className={`flex items-center gap-2 ${editing ? "" : "invisible pointer-events-none"}`}
+                            aria-hidden={!editing}
+                          >
+                            <div className="w-[190px] max-w-[45vw]">
+                              <div className="relative">
+                                <DatePicker
+                                  value={paymentDate}
+                                  onChange={setPaymentDate}
+                                  disabled={submitting || !editing}
+                                  className="!h-[38px] !pr-10"
+                                  dateFormat="yyyy. MM. dd"
+                                />
+                                <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-neutral-50">
+                                  <CalendarIcon />
+                                </span>
+                              </div>
                             </div>
+                            <button
+                              type="button"
+                              onClick={() => void confirmPayment(installment)}
+                              disabled={!editing || !paymentDate || submitting}
+                              aria-label={`${installment.installmentNumber}회차 납부 저장`}
+                              className="cursor-pointer grid h-9 w-9 place-items-center rounded-[5px] bg-primary-60 text-white disabled:opacity-50"
+                            >
+                              <CheckIcon />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setEditingInstallmentId(null);
+                                setPaymentDate(null);
+                              }}
+                              disabled={!editing || submitting}
+                              aria-label="납부 입력 취소"
+                              className="cursor-pointer grid h-9 w-9 place-items-center rounded-[5px] bg-neutral-30 text-white disabled:opacity-50"
+                            >
+                              <CloseIcon />
+                            </button>
                           </div>
-                          <button
-                            type="button"
-                            onClick={() => void confirmPayment(installment)}
-                            disabled={!paymentDate || submitting}
-                            aria-label={`${installment.installmentNumber}회차 납부 저장`}
-                            className="cursor-pointer grid h-9 w-9 place-items-center rounded-[5px] bg-primary-60 text-white disabled:opacity-50"
-                          >
-                            <CheckIcon />
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setEditingInstallmentId(null);
-                              setPaymentDate(null);
-                            }}
-                            disabled={submitting}
-                            aria-label="납부 입력 취소"
-                            className="cursor-pointer grid h-9 w-9 place-items-center rounded-[5px] bg-neutral-30 text-white disabled:opacity-50"
-                          >
-                            <CloseIcon />
-                          </button>
-                        </>
-                      ) : installment.status === "scheduled" ? (
-                        <button
-                          type="button"
-                          onClick={() => startPayment(installment)}
-                          disabled={!canChange || submitting}
-                          aria-label={`${installment.installmentNumber}회차 납부 처리`}
-                          className="cursor-pointer h-8 w-8 rounded-[6px] border border-neutral-40 bg-card disabled:cursor-not-allowed disabled:opacity-40"
-                        />
+
+                          {!editing && (
+                            <button
+                              type="button"
+                              onClick={() => startPayment(installment)}
+                              disabled={!canChange || submitting}
+                              aria-label={`${installment.installmentNumber}회차 납부 처리`}
+                              className="absolute right-0 top-1/2 -translate-y-1/2 cursor-pointer h-8 w-8 rounded-[6px] border border-neutral-40 bg-card disabled:cursor-not-allowed disabled:opacity-40"
+                            />
+                          )}
+                        </div>
                       ) : installment.status === "paid" ? (
                         <button
                           type="button"
@@ -867,17 +904,6 @@ export default function FeePaymentInfoModal({
             </button>
           </div>
         </>
-      ) : null}
-
-      {defaultProcedure ? (
-        <ProcedureSelectModal
-          open={procedureSelectOpen}
-          onClose={() => setProcedureSelectOpen(false)}
-          onConfirm={handleConfirmProcedure}
-          procedureScores={procedureScores}
-          defaultProcedure={defaultProcedure}
-          submitting={procedureSubmitting}
-        />
       ) : null}
 
       <FeePlanActionConfirmModal

--- a/src/components/debt-relief/result/ResultDetailContent.tsx
+++ b/src/components/debt-relief/result/ResultDetailContent.tsx
@@ -11,6 +11,7 @@ import LoadingSpinner from "@/components/common/LoadingSpinner";
 import EmptyState from "@/components/common/EmptyState";
 import {
   DIAGNOSIS_PROCEDURE_GUIDE_UNLOCKED_STATUSES,
+  DIAGNOSIS_PROCEDURE_STEP_UNLOCKED_STATUSES,
   RECOMMENDED_PROCEDURE_LABEL,
   type ProcedureStep,
   type RecommendedProcedure,
@@ -21,6 +22,7 @@ import ResultHeader from "./ResultHeader";
 import SectionCard from "./SectionCard";
 import SectionAiRecommendation from "./SectionAiRecommendation";
 import SectionDeliveryMessages from "./SectionDeliveryMessages";
+import DeliveryMessagesPopup from "./DeliveryMessagesPopup";
 import SectionProcedureScores from "./SectionProcedureScores";
 import SectionDebtStatus from "./SectionDebtStatus";
 import SectionRepaymentPlan from "./SectionRepaymentPlan";
@@ -36,6 +38,8 @@ export default function ResultDetailContent({ diagnosisId }: { diagnosisId: stri
   const [projectId] = useSelectedProjectId();
   const { isLawyer, ready: projectTypeReady } = useProjectType();
   const [activeId, setActiveId] = useState("overview");
+  // 모바일 전용 "전달사항" 토글(AI 추천 영역을 덮는 팝업). 데스크톱은 항상 접이식 섹션으로 쌓아 보여준다.
+  const [mobileMessagesOpen, setMobileMessagesOpen] = useState(false);
 
   // 변호사 프로젝트에서 공유받은(납품받은) 분석 건은 상담사가 직접 관리할 대상이 아니므로
   // AI 분석 추천·상담 멘트 숨김 + 추적 절차 변경도 읽기 전용으로 막는다.
@@ -196,16 +200,34 @@ export default function ResultDetailContent({ diagnosisId }: { diagnosisId: stri
         ) : (
           <>
             <SectionCard id="overview" compactTop className="max-md:!pt-0 md:!pb-[46px]">
-              <ResultHeader detail={detail} projectId={projectId} onCustomerMatchChange={refetch} />
+              <ResultHeader
+                detail={detail}
+                projectId={projectId}
+                onCustomerMatchChange={refetch}
+                showMessagesToggle={detail.messages.length > 0}
+                messagesOpen={mobileMessagesOpen}
+                onToggleMessages={() => setMobileMessagesOpen((previous) => !previous)}
+              />
               <div className="hidden md:block mt-0">
                 <ResultAnchorNav sections={sections} activeId={activeId} onNavigate={scrollTo} />
               </div>
+              {/* 데스크톱은 AI 추천 위에 전달사항을 쌓아 보여준다. 모바일은 공간이 좁아
+                  전달사항이 AI 추천을 밀어내지 않도록, ResultHeader의 말풍선 토글로 여는
+                  팝업(아래 relative 래퍼)이 AI 추천 영역을 덮는 방식으로 대신한다. */}
               {detail.messages.length > 0 ? (
-                <div className="mt-3 -mx-6 md:-mx-8 border-t border-neutral-30 px-6 pt-3 md:px-8">
+                <div className="hidden md:block mt-3 -mx-6 md:-mx-8 border-t border-neutral-30 px-6 pt-3 md:px-8">
                   <SectionDeliveryMessages messages={detail.messages} />
                 </div>
               ) : null}
-              <SectionAiRecommendation detail={detail} />
+              <div className="relative">
+                <SectionAiRecommendation detail={detail} showTopDivider={detail.messages.length === 0} />
+                {mobileMessagesOpen && detail.messages.length > 0 ? (
+                  <DeliveryMessagesPopup
+                    messages={detail.messages}
+                    onClose={() => setMobileMessagesOpen(false)}
+                  />
+                ) : null}
+              </div>
             </SectionCard>
 
             <SectionCard id="scores" compactTop topDivider>
@@ -239,6 +261,7 @@ export default function ResultDetailContent({ diagnosisId }: { diagnosisId: stri
             onChangeTrackingProcedure={handleChangeTrackingProcedure}
             canChangeTrackingProcedure={!lawyerReceivedReadOnly}
             locked={!DIAGNOSIS_PROCEDURE_GUIDE_UNLOCKED_STATUSES.includes(detail.status)}
+            stepLocked={!DIAGNOSIS_PROCEDURE_STEP_UNLOCKED_STATUSES.includes(detail.status)}
           />
         </SectionCard>
 

--- a/src/components/debt-relief/result/ResultHeader.tsx
+++ b/src/components/debt-relief/result/ResultHeader.tsx
@@ -77,20 +77,58 @@ function PaymentCardIcon() {
 
 // 계약대기중 + 결제정보 미입력 상태에서 "결제정보" 버튼 아래에 떠서 클릭을 유도하는 말풍선.
 // 결제정보를 입력해야 절차 진행(진행 절차 선택 → 절차진행중)이 시작된다는 걸 안내한다.
-function PaymentInfoNudgeBubble() {
+// 말풍선 클릭 또는 결제정보 버튼 클릭 시 닫힌다.
+function PaymentInfoNudgeBubble({ onDismiss }: { onDismiss: () => void }) {
   return (
-    <div
-      role="status"
-      className="pointer-events-none absolute left-1/2 top-full z-20 mt-2 w-max max-w-[180px] -translate-x-1/2 rounded-[8px] bg-neutral-90 dark:bg-neutral-20 px-3 py-2 text-center text-[12px] font-medium leading-[16px] text-white shadow-[0_8px_20px_rgba(0,0,0,0.18)]"
-    >
-      <span
-        className="absolute -top-[5px] left-1/2 h-2.5 w-2.5 -translate-x-1/2 rotate-45 bg-neutral-90 dark:bg-neutral-20"
-        aria-hidden
-      />
-      결제 정보를 입력하면
-      <br />
-      절차 진행이 시작돼요
+    <div className="absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2">
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="결제정보 안내 닫기"
+        className="animate-payment-nudge-in relative w-max max-w-[180px] cursor-pointer rounded-[8px] bg-neutral-90 dark:bg-neutral-20 px-3 py-2 text-center text-[12px] font-medium leading-[16px] text-white shadow-[0_8px_20px_rgba(0,0,0,0.18)]"
+      >
+        <span
+          className="absolute -top-[5px] left-1/2 h-2.5 w-2.5 -translate-x-1/2 rotate-45 bg-neutral-90 dark:bg-neutral-20"
+          aria-hidden
+        />
+        결제 정보를 입력하면
+        <br />
+        절차 진행이 시작돼요
+      </button>
     </div>
+  );
+}
+
+// 모바일 "전달사항" 토글 — 원형 테두리(34x34)가 아이콘 안에 포함돼 있어 버튼 자체엔
+// 별도 배경/테두리 클래스가 필요 없다. 꺼짐: neutral-30 테두리 + neutral-50 아이콘.
+// 켜짐: secondary-40 테두리 + secondary-10/50 배경(반투명) + secondary-20 아이콘.
+function AnnotationToggleIcon({ active }: { active: boolean }) {
+  return (
+    <svg width="34" height="34" viewBox="0 0 34 34" fill="none" aria-hidden>
+      <rect
+        x="0.5"
+        y="0.5"
+        width="33"
+        height="33"
+        rx="16.5"
+        className={
+          active
+            ? "fill-[rgba(228,237,255,0.5)] stroke-[var(--secondary-40)] dark:fill-blue-950 dark:stroke-blue-800"
+            : "fill-transparent stroke-neutral-30"
+        }
+      />
+      <path
+        d="M12.8333 13.6663H21.1667M12.8333 16.9997H16.1667M17 23.6663L13.6667 20.333H11.1667C10.2462 20.333 9.5 19.5868 9.5 18.6663V11.9997C9.5 11.0792 10.2462 10.333 11.1667 10.333H22.8333C23.7538 10.333 24.5 11.0792 24.5 11.9997V18.6663C24.5 19.5868 23.7538 20.333 22.8333 20.333H20.3333L17 23.6663Z"
+        className={
+          active
+            ? "stroke-[var(--secondary-20)] dark:stroke-blue-300"
+            : "stroke-neutral-50 dark:stroke-neutral-60"
+        }
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   );
 }
 
@@ -186,6 +224,11 @@ type Props = {
   detail: DiagnosisDetail;
   projectId: string | null;
   onCustomerMatchChange: () => void;
+  // 모바일 전용 "전달사항" 토글 아이콘. AI 분석 추천을 보여줄 수 있는 화면(전달사항이
+  // 그 영역을 덮는 팝업으로 뜨는 화면)에서만 부모가 넘겨준다.
+  showMessagesToggle?: boolean;
+  messagesOpen?: boolean;
+  onToggleMessages?: () => void;
 };
 
 function LinkedCustomerMenu({
@@ -215,9 +258,11 @@ function LinkedCustomerMenu({
   );
 }
 
-function MoreOptionsIcon() {
+// size: 데스크톱 헤더는 36(기본), 모바일 고객정보 칩 안에서는 24로 축소해 쓴다(viewBox는
+// 36x36 그대로 두고 렌더 크기만 줄여 내부 비율을 유지).
+function MoreOptionsIcon({ size = 36 }: { size?: number }) {
   return (
-    <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
+    <svg width={size} height={size} viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
       <rect
         x="0.5"
         y="0.5"
@@ -287,13 +332,21 @@ function AssigneeProfileChip({
   );
 }
 
-export default function ResultHeader({ detail, projectId, onCustomerMatchChange }: Props) {
+export default function ResultHeader({
+  detail,
+  projectId,
+  onCustomerMatchChange,
+  showMessagesToggle = false,
+  messagesOpen = false,
+  onToggleMessages,
+}: Props) {
   const router = useRouter();
   const { openCustomerModal } = useCustomerModal();
   const { isAnalysis, isLawyer, ready: projectTypeReady } = useProjectType();
   const [linkStep, setLinkStep] = useState<null | "mode" | "existing" | "create">(null);
   const [shareOpen, setShareOpen] = useState(false);
   const [paymentInfoOpen, setPaymentInfoOpen] = useState(false);
+  const [paymentNudgeDismissed, setPaymentNudgeDismissed] = useState(false);
   const [customerInfoOpen, setCustomerInfoOpen] = useState(false);
   const [linkedMenuOpen, setLinkedMenuOpen] = useState(false);
   const mobileLinkedMenuRef = useRef<HTMLDivElement>(null);
@@ -303,10 +356,21 @@ export default function ResultHeader({ detail, projectId, onCustomerMatchChange 
   const showOwnerActions = projectTypeReady && isAnalysis;
   const showAssigneeProfile = projectTypeReady && isLawyer;
   // 계약대기중인데 결제정보가 아직 없으면 절차 진행이 시작되지 않은 상태 — 결제정보 입력을 유도한다.
+  // 말풍선·결제정보 버튼 클릭으로 닫으면 다시 띄우지 않는다.
   const showPaymentNudge =
     (showOwnerActions || showAssigneeProfile) &&
     detail.status === "contract_pending" &&
-    !detail.feePlan;
+    !detail.feePlan &&
+    !paymentNudgeDismissed;
+
+  const handleOpenPaymentInfo = () => {
+    setPaymentNudgeDismissed(true);
+    setPaymentInfoOpen(true);
+  };
+
+  const handleDismissPaymentNudge = () => {
+    setPaymentNudgeDismissed(true);
+  };
 
   const phonePreview = detail.phone ? formatContactForDisplay(detail.phone) : "";
   const linkedLabel =
@@ -329,6 +393,17 @@ export default function ResultHeader({ detail, projectId, onCustomerMatchChange 
   }, [linkedMenuOpen]);
 
   const handleEdit = () => {
+    // 정보수정(재분석)은 상담중/반려된 건만 가능 — 계약 이후(계약대기중 이상) 건은 절차가 이미
+    // 진행돼 입력값을 되돌려 재분석하면 안 되므로 서버도 이 상태에서만 허용한다.
+    if (detail.status !== "consulting" && detail.status !== "rejected") {
+      showErrorModal({
+        type: "info",
+        title: "정보수정 불가",
+        headline: "정보수정은 상담중 또는 반려된 분석 건만 가능합니다.",
+        hideCancel: true,
+      });
+      return;
+    }
     router.push(`/debt-relief/${detail.id}/edit`);
   };
   const handleGoToList = () => {
@@ -408,117 +483,150 @@ export default function ResultHeader({ detail, projectId, onCustomerMatchChange 
     </button>
   );
 
+  // 모바일 2줄째 "김민수 · 42세 · 자영업 ⋯" 칩 안에 들어가는 축소 버전(24px).
+  const customerInfoButtonCompact = (
+    <button
+      type="button"
+      onClick={() => setCustomerInfoOpen(true)}
+      aria-label="고객정보"
+      className="cursor-pointer shrink-0 hover:opacity-80 transition-opacity"
+    >
+      <MoreOptionsIcon size={24} />
+    </button>
+  );
+
   return (
     <>
-      {/* 모바일: 뒤로+제목/메타+⋯ | 수정·고객연결·공유(영업점) 또는 담당직원(변호사) — 영역 높이 60px */}
-      <div className="flex md:hidden items-center justify-between gap-3 h-[60px]">
-        <div className="flex items-center gap-2 min-w-0 flex-1">
-          <button
-            type="button"
-            onClick={handleGoToList}
-            aria-label="목록으로"
-            className="cursor-pointer w-9 h-9 -ml-1.5 grid place-items-center text-foreground hover:opacity-70 shrink-0"
-          >
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" className="block">
-              <path
-                d="M15 19L8 12L15 5"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </button>
-          <div className="min-w-0">
-            <div className="flex items-center gap-1.5 min-w-0">
-              <h1 className="text-[16px] font-semibold leading-[19px] tracking-[0.2px] text-black dark:text-neutral-90 truncate">
-                {RECOMMENDED_PROCEDURE_LABEL[detail.trackingProcedure]}
-              </h1>
-              {statusBadge}
-            </div>
-            <p className="mt-1 text-[16px] font-medium leading-[19px] tracking-[0.2px] text-neutral-60 truncate">
-              {customerSummaryLabel}
-            </p>
-          </div>
-          {customerInfoButton}
-        </div>
-
-        {showOwnerActions ? (
-          <div className="flex items-center gap-1.5 shrink-0">
-            <div className="relative">
-              <button
-                type="button"
-                onClick={() => setPaymentInfoOpen(true)}
-                aria-label="결제정보"
-                className="cursor-pointer w-9 h-9 grid place-items-center rounded-[8px] border border-neutral-30 text-foreground hover:bg-neutral-10"
-              >
-                <PaymentCardIcon />
-              </button>
-              {showPaymentNudge && <PaymentInfoNudgeBubble />}
-            </div>
-
+      {/* 모바일: 2줄 구성 — 1줄(뒤로+제목 | 수정·고객연결·공유(영업점) 또는 담당직원(변호사)),
+          2줄(고객메타+⋯+상태뱃지 | 전달사항 토글). 전달사항이 늘어나도 1줄 높이엔 영향 없음.
+          두 줄 사이에 카드 풀폭 구분선(SectionAiRecommendation에 있던 것을 여기로 옮김). */}
+      <div className="flex md:hidden flex-col py-1.5">
+        <div className="flex items-center justify-between gap-3 pb-2">
+          <div className="flex items-center gap-2 min-w-0 flex-1">
             <button
               type="button"
-              onClick={handleEdit}
-              aria-label="정보수정"
-              className="cursor-pointer w-9 h-9 grid place-items-center rounded-[8px] border border-neutral-30 text-foreground hover:bg-neutral-10"
+              onClick={handleGoToList}
+              aria-label="목록으로"
+              className="cursor-pointer w-9 h-9 -ml-1.5 grid place-items-center text-foreground hover:opacity-70 shrink-0"
             >
-              <EditIcon />
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" className="block">
+                <path
+                  d="M15 19L8 12L15 5"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
             </button>
+            <h1 className="text-[16px] font-semibold leading-[19px] tracking-[0.2px] text-black dark:text-neutral-90 truncate">
+              {RECOMMENDED_PROCEDURE_LABEL[detail.trackingProcedure]}
+            </h1>
+          </div>
 
-            {isMatched ? (
-              <div className="relative" ref={mobileLinkedMenuRef}>
+          {showOwnerActions ? (
+            <div className="flex items-center gap-1.5 shrink-0">
+              <div className="relative">
                 <button
                   type="button"
-                  onClick={() => setLinkedMenuOpen((prev) => !prev)}
-                  aria-label="연결된 고객"
-                  aria-expanded={linkedMenuOpen}
-                  className="cursor-pointer w-9 h-9 grid place-items-center rounded-[8px] bg-secondary-10 dark:bg-blue-950 border border-secondary-60 dark:border-blue-800 text-secondary-60 dark:text-blue-300 hover:opacity-90"
+                  onClick={handleOpenPaymentInfo}
+                  aria-label="결제정보"
+                  className="cursor-pointer w-9 h-9 grid place-items-center rounded-[8px] border border-neutral-30 text-foreground hover:bg-neutral-10"
+                >
+                  <PaymentCardIcon />
+                </button>
+                {showPaymentNudge && <PaymentInfoNudgeBubble onDismiss={handleDismissPaymentNudge} />}
+              </div>
+
+              <button
+                type="button"
+                onClick={handleEdit}
+                aria-label="정보수정"
+                className="cursor-pointer w-9 h-9 grid place-items-center rounded-[8px] border border-neutral-30 text-foreground hover:bg-neutral-10"
+              >
+                <EditIcon />
+              </button>
+
+              {isMatched ? (
+                <div className="relative" ref={mobileLinkedMenuRef}>
+                  <button
+                    type="button"
+                    onClick={() => setLinkedMenuOpen((prev) => !prev)}
+                    aria-label="연결된 고객"
+                    aria-expanded={linkedMenuOpen}
+                    className="cursor-pointer w-9 h-9 grid place-items-center rounded-[8px] bg-secondary-10 dark:bg-blue-950 border border-secondary-60 dark:border-blue-800 text-secondary-60 dark:text-blue-300 hover:opacity-90"
+                  >
+                    <LinkedCustomerIcon />
+                  </button>
+                  <LinkedCustomerMenu
+                    open={linkedMenuOpen}
+                    onOpenCustomerInfo={handleOpenCustomerDetail}
+                    onUnlink={handleUnlink}
+                  />
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleOpenMatchModal}
+                  aria-label="고객 연결"
+                  className="cursor-pointer w-9 h-9 grid place-items-center rounded-[8px] border border-neutral-30 text-foreground hover:bg-neutral-10"
                 >
                   <LinkedCustomerIcon />
                 </button>
-                <LinkedCustomerMenu
-                  open={linkedMenuOpen}
-                  onOpenCustomerInfo={handleOpenCustomerDetail}
-                  onUnlink={handleUnlink}
-                />
-              </div>
-            ) : (
+              )}
+
               <button
                 type="button"
-                onClick={handleOpenMatchModal}
-                aria-label="고객 연결"
-                className="cursor-pointer w-9 h-9 grid place-items-center rounded-[8px] border border-neutral-30 text-foreground hover:bg-neutral-10"
+                onClick={() => setShareOpen(true)}
+                aria-label="공유하기"
+                className={detail.isShared ? ICON_BTN_SHARED : ICON_BTN}
               >
-                <LinkedCustomerIcon />
+                <ShareNodesIcon />
               </button>
-            )}
+            </div>
+          ) : showAssigneeProfile ? (
+            <div className="flex items-center gap-3 shrink-0">
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={handleOpenPaymentInfo}
+                  aria-label="결제정보"
+                  className="cursor-pointer w-9 h-9 grid place-items-center rounded-[8px] border border-neutral-30 text-foreground hover:bg-neutral-10"
+                >
+                  <PaymentCardIcon />
+                </button>
+                {showPaymentNudge && <PaymentInfoNudgeBubble onDismiss={handleDismissPaymentNudge} />}
+              </div>
+              {assigneeProfile}
+            </div>
+          ) : null}
+        </div>
 
+        <div className="-mx-6 border-t border-neutral-30" />
+
+        <div className="flex items-center justify-between gap-3 pt-2">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <div className="flex min-w-0 items-center gap-2.5 rounded-full border border-neutral-30 px-3 py-1.5">
+              <p className="min-w-0 truncate text-[14px] font-semibold leading-5 tracking-[-0.04em] text-black dark:text-neutral-90">
+                {customerSummaryLabel}
+              </p>
+              {customerInfoButtonCompact}
+            </div>
+            {statusBadge}
+          </div>
+
+          {showMessagesToggle ? (
             <button
               type="button"
-              onClick={() => setShareOpen(true)}
-              aria-label="공유하기"
-              className={detail.isShared ? ICON_BTN_SHARED : ICON_BTN}
+              onClick={onToggleMessages}
+              aria-label="전달사항"
+              aria-pressed={messagesOpen}
+              className="cursor-pointer shrink-0 hover:opacity-80 transition-opacity"
             >
-              <ShareNodesIcon />
+              <AnnotationToggleIcon active={messagesOpen} />
             </button>
-          </div>
-        ) : showAssigneeProfile ? (
-          <div className="flex items-center gap-3 shrink-0">
-            <div className="relative">
-              <button
-                type="button"
-                onClick={() => setPaymentInfoOpen(true)}
-                aria-label="결제정보"
-                className="cursor-pointer w-9 h-9 grid place-items-center rounded-[8px] border border-neutral-30 text-foreground hover:bg-neutral-10"
-              >
-                <PaymentCardIcon />
-              </button>
-              {showPaymentNudge && <PaymentInfoNudgeBubble />}
-            </div>
-            {assigneeProfile}
-          </div>
-        ) : null}
+          ) : null}
+        </div>
       </div>
 
       {/* 데스크톱: 뒤로 | 제목 | 메타  ……  액션 세트(영업점) 또는 담당직원(변호사) */}
@@ -589,11 +697,11 @@ export default function ResultHeader({ detail, projectId, onCustomerMatchChange 
               <span className="leading-none">정보수정</span>
             </button>
             <div className="relative">
-              <button type="button" className={ACTION_BTN} onClick={() => setPaymentInfoOpen(true)}>
+              <button type="button" className={ACTION_BTN} onClick={handleOpenPaymentInfo}>
                 <PaymentCardIcon />
                 <span className="leading-none">결제정보</span>
               </button>
-              {showPaymentNudge && <PaymentInfoNudgeBubble />}
+              {showPaymentNudge && <PaymentInfoNudgeBubble onDismiss={handleDismissPaymentNudge} />}
             </div>
             <button
               type="button"
@@ -607,11 +715,11 @@ export default function ResultHeader({ detail, projectId, onCustomerMatchChange 
         ) : showAssigneeProfile ? (
           <div className="flex items-center justify-end gap-4 shrink-0">
             <div className="relative">
-              <button type="button" className={ACTION_BTN} onClick={() => setPaymentInfoOpen(true)}>
+              <button type="button" className={ACTION_BTN} onClick={handleOpenPaymentInfo}>
                 <PaymentCardIcon />
                 <span className="leading-none">결제정보</span>
               </button>
-              {showPaymentNudge && <PaymentInfoNudgeBubble />}
+              {showPaymentNudge && <PaymentInfoNudgeBubble onDismiss={handleDismissPaymentNudge} />}
             </div>
             {assigneeProfile}
           </div>

--- a/src/components/debt-relief/result/SectionAiRecommendation.tsx
+++ b/src/components/debt-relief/result/SectionAiRecommendation.tsx
@@ -37,14 +37,25 @@ function RecommendationChips({
   );
 }
 
-export default function SectionAiRecommendation({ detail }: { detail: DiagnosisDetail }) {
+export default function SectionAiRecommendation({
+  detail,
+  showTopDivider = true,
+}: {
+  detail: DiagnosisDetail;
+  // 데스크톱에서 바로 위에 전달사항 카드가 쌓여 있으면 그 카드 자체 테두리와 겹쳐 보이므로
+  // 이 구분선을 끈다(false). 전달사항이 없으면 헤더와의 유일한 구분선이라 계속 그린다.
+  showTopDivider?: boolean;
+}) {
   const { recommendation, successProbability } = detail;
 
   return (
     // 구분선만 카드 풀폭. 피그마: divider→라벨 46px / 좌측 68px(=32+36) / 도넛 우측 90px
-    // 와이드(PC) 레이아웃은 공식 desktop BP(lg=1080)부터 — 수치·구조는 기존과 동일하게 유지.
+    // 와이드(PC) 레이아웃은 공식 desktop BP(1080)부터 — 수치·구조는 기존과 동일하게 유지.
     // md~lg(태블릿)는 컴팩트 레이아웃으로 두어 문구/도넛 겹침을 피한다.
-    <div className="mt-0 md:mt-[22px] -mx-6 md:-mx-8 border-t border-neutral-30 pt-5 md:pt-[46px] px-6 md:pl-8 md:pr-8 lg:pr-[90px]">
+    // 모바일은 이 구분선을 ResultHeader의 1줄·2줄 사이로 옮겨서(border-t-0) 여기서는 안 그린다.
+    <div
+      className={`mt-0 md:mt-[22px] -mx-6 md:-mx-8 border-t-0 ${showTopDivider ? "md:border-t" : ""} border-neutral-30 pt-5 md:pt-[46px] px-6 md:pl-8 md:pr-8 lg:pr-[90px]`}
+    >
       {/* 모바일·태블릿: 헤더 → (제목+설명 | 도넛) → 칩 */}
       <div className="lg:hidden">
         <div className="flex items-center h-5 mb-2">

--- a/src/components/debt-relief/result/SectionDeliveryMessages.tsx
+++ b/src/components/debt-relief/result/SectionDeliveryMessages.tsx
@@ -10,7 +10,16 @@ const TYPE_LABEL: Record<DiagnosisMessageType, string> = {
   accept: "수락",
   fee_create: "결제",
   fee_update: "결제",
+  fee_stop: "중단",
+  fee_refund: "환불",
 };
+
+// 타임라인 점을 반려와 동일한 빨간색으로 표시하는 타입 — 반려/중단/환불은 모두 "안 좋은 소식" 성격.
+const DANGER_MESSAGE_TYPES: ReadonlySet<DiagnosisMessageType> = new Set([
+  "reject",
+  "fee_stop",
+  "fee_refund",
+]);
 
 function ChevronIcon({ expanded }: { expanded: boolean }) {
   return (
@@ -35,13 +44,13 @@ function ChevronIcon({ expanded }: { expanded: boolean }) {
 
 function TimelineDot({
   isLatest,
-  isReject,
+  isDanger,
 }: {
   isLatest: boolean;
-  isReject: boolean;
+  isDanger: boolean;
 }) {
-  // 최신 항목: 파란점. 최신이 반려면 빨간점. 그 외 반려도 빨간점(시안), 나머지는 회색.
-  const className = isReject
+  // 최신 항목: 파란점. 최신이 반려/중단/환불이면 빨간점. 그 외 반려/중단/환불도 빨간점(시안), 나머지는 회색.
+  const className = isDanger
     ? "bg-danger-20"
     : isLatest
       ? "bg-secondary-20"
@@ -55,14 +64,9 @@ function TimelineDot({
   );
 }
 
-export default function SectionDeliveryMessages({
-  messages,
-}: {
-  messages: DiagnosisMessage[];
-}) {
-  // false(접힘, 기본값) = 약 3건 높이로 제한하고 넘치면 내부 스크롤. true(펼침) = 높이 제한 없이 전체 표시.
-  const [expanded, setExpanded] = useState(false);
-
+// 전달사항 타임라인 목록 — 데스크톱 접이식 섹션(SectionDeliveryMessages)과 모바일 팝업
+// (DeliveryMessagesPopup)이 동일한 마크업을 공유한다.
+export function DeliveryMessageTimeline({ messages }: { messages: DiagnosisMessage[] }) {
   const ordered = useMemo(
     () =>
       [...messages].sort(
@@ -72,6 +76,68 @@ export default function SectionDeliveryMessages({
   );
 
   if (ordered.length === 0) return null;
+
+  return (
+    <ul>
+      {ordered.map((item, index) => {
+        const isLatest = index === 0;
+        const isLast = index === ordered.length - 1;
+        const isDanger = DANGER_MESSAGE_TYPES.has(item.type);
+        const meta = [item.memberName, item.projectName].filter(Boolean).join(" ");
+
+        return (
+          <li key={`${item.type}-${item.createdAt}-${index}`} className="flex gap-3">
+            {/* 점 아래부터 다음 행 시작까지 세로선이 이어져 점·점 사이 빈 공간이 없음 */}
+            <div className="flex w-3 shrink-0 flex-col items-center self-stretch">
+              <TimelineDot isLatest={isLatest} isDanger={isDanger} />
+              {!isLast ? <span className="w-px flex-1 bg-neutral-30" aria-hidden /> : null}
+            </div>
+
+            <div className={`min-w-0 flex-1 ${isLast ? "" : "pb-6"}`}>
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                  <span className="text-[13px] font-bold leading-4 tracking-[-0.02em] text-foreground">
+                    {TYPE_LABEL[item.type]}
+                  </span>
+                  {meta ? (
+                    <span className="text-[12px] font-normal leading-[14px] tracking-[-0.02em] text-neutral-50">
+                      {meta}
+                    </span>
+                  ) : null}
+                </div>
+                <time
+                  dateTime={item.createdAt}
+                  className="shrink-0 whitespace-nowrap text-[14px] font-medium leading-5 text-neutral-50"
+                >
+                  {formatDateTimeDisplay(item.createdAt)}
+                </time>
+              </div>
+              {item.message?.trim() ? (
+                <p className="mt-1 whitespace-pre-wrap break-words text-[13px] font-medium leading-4 tracking-[-0.02em] text-neutral-80">
+                  {item.message}
+                </p>
+              ) : (
+                <p className="mt-1 text-[13px] font-medium leading-4 tracking-[-0.02em] text-neutral-40 dark:text-neutral-60">
+                  내용 없음
+                </p>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export default function SectionDeliveryMessages({
+  messages,
+}: {
+  messages: DiagnosisMessage[];
+}) {
+  // false(접힘, 기본값) = 약 3건 높이로 제한하고 넘치면 내부 스크롤. true(펼침) = 높이 제한 없이 전체 표시.
+  const [expanded, setExpanded] = useState(false);
+
+  if (messages.length === 0) return null;
 
   return (
     <section
@@ -92,58 +158,9 @@ export default function SectionDeliveryMessages({
         </span>
       </button>
 
-      <ul
-        className={`px-6 py-4 ${
-          expanded ? "" : "max-h-[260px] overflow-y-auto"
-        }`}
-      >
-        {ordered.map((item, index) => {
-          const isLatest = index === 0;
-          const isLast = index === ordered.length - 1;
-          const isReject = item.type === "reject";
-          const meta = [item.memberName, item.projectName].filter(Boolean).join(" ");
-
-          return (
-            <li key={`${item.type}-${item.createdAt}-${index}`} className="flex gap-3">
-              {/* 점 아래부터 다음 행 시작까지 세로선이 이어져 점·점 사이 빈 공간이 없음 */}
-              <div className="flex w-3 shrink-0 flex-col items-center self-stretch">
-                <TimelineDot isLatest={isLatest} isReject={isReject} />
-                {!isLast ? <span className="w-px flex-1 bg-neutral-30" aria-hidden /> : null}
-              </div>
-
-              <div className={`min-w-0 flex-1 ${isLast ? "" : "pb-6"}`}>
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                    <span className="text-[13px] font-bold leading-4 tracking-[-0.02em] text-foreground">
-                      {TYPE_LABEL[item.type]}
-                    </span>
-                    {meta ? (
-                      <span className="text-[12px] font-normal leading-[14px] tracking-[-0.02em] text-neutral-50">
-                        {meta}
-                      </span>
-                    ) : null}
-                  </div>
-                  <time
-                    dateTime={item.createdAt}
-                    className="shrink-0 whitespace-nowrap text-[14px] font-medium leading-5 text-neutral-50"
-                  >
-                    {formatDateTimeDisplay(item.createdAt)}
-                  </time>
-                </div>
-                {item.message?.trim() ? (
-                  <p className="mt-1 whitespace-pre-wrap break-words text-[13px] font-medium leading-4 tracking-[-0.02em] text-neutral-80">
-                    {item.message}
-                  </p>
-                ) : (
-                  <p className="mt-1 text-[13px] font-medium leading-4 tracking-[-0.02em] text-neutral-40 dark:text-neutral-60">
-                    내용 없음
-                  </p>
-                )}
-              </div>
-            </li>
-          );
-        })}
-      </ul>
+      <div className={`px-6 py-4 ${expanded ? "" : "max-h-[260px] overflow-y-auto"}`}>
+        <DeliveryMessageTimeline messages={messages} />
+      </div>
     </section>
   );
 }

--- a/src/components/debt-relief/result/SectionProcedureGuide.tsx
+++ b/src/components/debt-relief/result/SectionProcedureGuide.tsx
@@ -348,9 +348,12 @@ type Props = {
   onChangeTrackingProcedure?: (procedure: RecommendedProcedure) => void;
   // false면 셀렉트를 비활성 배지로 대체 (예: 변호사 프로젝트가 공유받은 건은 읽기 전용)
   canChangeTrackingProcedure?: boolean;
-  // true면 절차 확인(펼치기)은 그대로 두고, 절차 전환/현재 단계 설정/문자 발송 등 실제 작업만 막는다.
+  // true면 절차 확인(펼치기)은 그대로 두고, 절차 전환/문자 발송 등 실제 작업만 막는다.
   // (예: 계약 체결 전 상태 — 내용은 미리 볼 수 있어야 하지만 아직 작업 대상은 아님)
   locked?: boolean;
+  // "현재 단계로 설정" 전용 잠금. currentProcedureStep 지정은 실 API가 절차진행중(in_progress)
+  // 상태에서만 허용해서 locked보다 좁게 막아야 한다 — 생략 시 locked를 그대로 따른다(안전한 기본값).
+  stepLocked?: boolean;
 };
 
 export default function SectionProcedureGuide({
@@ -359,6 +362,7 @@ export default function SectionProcedureGuide({
   onChangeTrackingProcedure,
   canChangeTrackingProcedure = true,
   locked = false,
+  stepLocked = locked,
 }: Props) {
   const { procedureGuide: guide } = detail;
   const { member } = useMyMember();
@@ -456,7 +460,7 @@ export default function SectionProcedureGuide({
               expanded={expanded.has(step.step)}
               onToggle={() => toggle(step.step)}
               isCurrent={step.step === currentStep}
-              canSetCurrent={step.step > currentStep && !locked}
+              canSetCurrent={step.step > currentStep && !stepLocked}
               onSetCurrent={() => handleSetCurrent(step)}
               onSendSms={() => setSmsStep(step)}
               smsDisabled={!canSendSms || locked}

--- a/src/components/debt-relief/result/SectionRepaymentPlan.tsx
+++ b/src/components/debt-relief/result/SectionRepaymentPlan.tsx
@@ -150,7 +150,7 @@ export default function SectionRepaymentPlan({ detail }: { detail: DiagnosisDeta
           <h2 className="inline-flex h-6 items-center text-[16px] font-semibold leading-none tracking-[0.2px] text-foreground">
             예상 변제 계획
           </h2>
-          <DisclaimerInfoTooltip label="예상 변제 계획 안내">
+          <DisclaimerInfoTooltip label="예상 변제 계획 안내" maxWidthPx={480} fitContent>
             아래 금액·기간은 예상 시뮬레이션이며, 실제 인가·면책 범위는
             <br />
             법원 결정에 따라 달라질 수 있습니다.

--- a/src/components/debt-relief/result/SectionSmsSend.tsx
+++ b/src/components/debt-relief/result/SectionSmsSend.tsx
@@ -95,7 +95,7 @@ export default function SectionSmsSend({ detail }: { detail: DiagnosisDetail }) 
           {label}
         </button>
       ))}
-      <span className="text-[14px] text-neutral-60">
+      <span className="text-[14px] leading-[100%] tracking-[0px] font-semibold text-neutral-60">
         {canSendSms
           ? `${detail.customerName} ${formatContactForDisplay(detail.phone)}`
           : "연락처 정보가 없어 문자 발송이 불가능합니다"}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -91,16 +91,9 @@ export default function Header() {
     if (!mounted || typeof window === "undefined") return;
 
     const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
-    const prefersDark =
-      window.matchMedia &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches;
-
+    // 저장된 값이 없으면 OS 설정과 무관하게 light를 기본값으로 사용
     const initialTheme =
-      storedTheme === "dark" || storedTheme === "light"
-        ? storedTheme
-        : prefersDark
-        ? "dark"
-        : "light";
+      storedTheme === "dark" || storedTheme === "light" ? storedTheme : "light";
 
     setIsDarkMode(initialTheme === "dark");
   }, [mounted]);

--- a/src/components/layout/LiteHeader.tsx
+++ b/src/components/layout/LiteHeader.tsx
@@ -74,15 +74,9 @@ export default function LiteHeader() {
   useEffect(() => {
     if (!mounted || typeof window === "undefined") return;
     const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
-    const prefersDark =
-      window.matchMedia &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches;
+    // 저장된 값이 없으면 OS 설정과 무관하게 light를 기본값으로 사용
     const initialTheme =
-      storedTheme === "dark" || storedTheme === "light"
-        ? storedTheme
-        : prefersDark
-        ? "dark"
-        : "light";
+      storedTheme === "dark" || storedTheme === "light" ? storedTheme : "light";
     setIsDarkMode(initialTheme === "dark");
   }, [mounted]);
 

--- a/src/hooks/useAnalysisProcedureMaster.ts
+++ b/src/hooks/useAnalysisProcedureMaster.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { AnalysisService } from "@/services/analysis";
+import { PROCEDURE_FROM_ANALYSIS } from "@/services/debtRelief";
+import {
+  PROCEDURE_PROGRESS_STEP_TITLES,
+  type ProcedureStepTitlesByProcedure,
+} from "@/types/debtRelief";
+
+// 절차 마스터 데이터는 로그인 토큰과 동일한 24시간 생명주기로 캐싱한다 — 거의 바뀌지 않는 값이라
+// 매 마운트마다 다시 불러올 필요가 없다.
+const PROCEDURE_MASTER_STALE_TIME = 24 * 60 * 60 * 1000;
+const PROCEDURE_MASTER_GC_TIME = 25 * 60 * 60 * 1000;
+
+export const analysisProcedureMasterKeys = {
+  byProject: (projectId: string | null) => ["analysis", "procedures", projectId] as const,
+};
+
+async function fetchStepTitlesByProcedure(
+  projectId: string
+): Promise<ProcedureStepTitlesByProcedure> {
+  const response = await AnalysisService.procedures(projectId);
+  const masters = response.data.data;
+
+  // 하드코딩 폴백을 베이스로 두고 실 데이터로 덮어써서, 백엔드가 특정 절차를 응답에서
+  // 빠뜨려도(예: 아직 개편 전) 나머지 절차는 정상 값을 유지한다.
+  const result: ProcedureStepTitlesByProcedure = { ...PROCEDURE_PROGRESS_STEP_TITLES };
+  for (const master of masters) {
+    const key = PROCEDURE_FROM_ANALYSIS[master.procedure];
+    result[key] = master.steps.map((step) => step.title);
+  }
+  return result;
+}
+
+/**
+ * 절차별 단계명 마스터 데이터(GET /v1/analysis/procedures). 목록 화면의 "진행단계"(n/m) 표시에 쓰인다.
+ * 로딩 중이거나 요청이 실패하면 하드코딩 폴백(PROCEDURE_PROGRESS_STEP_TITLES)을 그대로 반환해
+ * 목록 렌더링이 깨지지 않는다.
+ */
+export function useAnalysisProcedureMaster(projectId: string | null) {
+  const query = useQuery({
+    queryKey: analysisProcedureMasterKeys.byProject(projectId),
+    queryFn: () => fetchStepTitlesByProcedure(projectId as string),
+    enabled: Boolean(projectId),
+    staleTime: PROCEDURE_MASTER_STALE_TIME,
+    gcTime: PROCEDURE_MASTER_GC_TIME,
+    retry: 1,
+  });
+
+  return {
+    stepTitlesByProcedure: query.data ?? PROCEDURE_PROGRESS_STEP_TITLES,
+    loading: query.isLoading,
+  };
+}

--- a/src/providers/ErrorFeedbackModalProvider.tsx
+++ b/src/providers/ErrorFeedbackModalProvider.tsx
@@ -234,7 +234,7 @@ export default function ErrorFeedbackModalProvider({
                     aria-label="close error modal"
                   >
                     <svg className="translate-[3px_1px]" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                      <path d="M6 18L18 6M6 6L18 18" stroke="#B0B0B0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+                      <path d="M6 18L18 6M6 6L18 18" stroke="#B0B0B0" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
                     </svg>
                   </button>
                 )}

--- a/src/services/debtRelief.ts
+++ b/src/services/debtRelief.ts
@@ -87,7 +87,7 @@ const PROCEDURE_TO_ANALYSIS: Record<RecommendedProcedure, AnalysisProcedureType>
   bankruptcy: "bankruptcy",
 };
 
-const PROCEDURE_FROM_ANALYSIS: Record<AnalysisProcedureType, RecommendedProcedure> = {
+export const PROCEDURE_FROM_ANALYSIS: Record<AnalysisProcedureType, RecommendedProcedure> = {
   individual_rehabilitation: "individual_rehab",
   debt_adjustment: "debt_adjustment",
   bankruptcy: "bankruptcy",
@@ -397,6 +397,7 @@ function toDiagnosisListItem(item: AnalysisListItem): DiagnosisListItem {
     age: typeof item.age === "number" ? item.age : undefined,
     ageGroupLabel: resolveAgeGroupLabel(item.ageGroup),
     gender: item.gender ?? undefined,
+    occupation: item.employmentType ?? undefined,
     region: item.region,
     totalDebtManwon: item.totalDebt,
     monthlyAvailableIncomeManwon: item.disposableIncome,
@@ -406,6 +407,10 @@ function toDiagnosisListItem(item: AnalysisListItem): DiagnosisListItem {
     // 아직 절차 추적을 시작하지 않아 null이면 1단계로 표시
     progressStep: item.currentProcedureStep ?? 1,
     isShared: item.isShared,
+    deliveryStatus: item.deliveryStatus ?? null,
+    lawyerProjectId: item.lawyerProjectId ?? null,
+    lawyerProjectName: item.lawyerProjectName ?? null,
+    partnerId: item.partnerId ?? null,
     isCustomerConnected: item.isCustomerConnected,
     consultedAt: item.createdAt.slice(0, 10),
     assigneeName: assigneeName || undefined,

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -272,9 +272,9 @@ export type AnalysisDetail = {
   updatedAt: string;
 };
 
-/** 분석 건 액션(공유/반려/수락/수임료 입력·수정) 메시지 히스토리 항목 */
+/** 분석 건 액션(공유/반려/수락/수임료 입력·수정·중단·환불) 메시지 히스토리 항목 */
 export type AnalysisMessageDto = {
-  type: "share" | "reject" | "accept" | "fee_create" | "fee_update";
+  type: "share" | "reject" | "accept" | "fee_create" | "fee_update" | "fee_stop" | "fee_refund";
   memberName: string;
   projectId: number;
   projectName?: string | null;
@@ -502,8 +502,9 @@ export type DeliverAnalysisInput = {
   partnerId: number;
   /** 공유 시 함께 전달할 연락처 (선택) */
   contact?: string;
-  /** 공유 시 함께 전달할 참고사항 (선택) */
-  referenceNote?: string;
+  /** 공유 시 함께 전달할 참고사항 (선택). 실 API 필드명은 referenceNote가 아니라 message —
+   * 히스토리(messages)로 누적되는 자유 텍스트다. */
+  message?: string;
 };
 
 export type DeliverAnalysisResponse = ApiSuccess<AnalysisDelivery>;
@@ -570,7 +571,8 @@ export type BulkDeleteAnalysisResponse = ApiSuccess<BulkDeleteAnalysisResult>;
 export type BulkDeliverAnalysisItem = {
   analysisId: number;
   contact?: string;
-  referenceNote?: string;
+  /** 실 API 필드명은 referenceNote가 아니라 message. */
+  message?: string;
 };
 
 /**

--- a/src/types/debtRelief.ts
+++ b/src/types/debtRelief.ts
@@ -16,11 +16,20 @@ export const DIAGNOSIS_STATUS_LABEL: Record<AnalysisStatus, string> = {
   suspended: "중단됨",
 };
 
-// 절차안내는 계약 체결(contract_pending) 이후부터 이용 가능.
+// 절차안내는 계약 체결(contract_pending) 이후부터 이용 가능. 트래킹 절차 전환(개인회생/채무조정/
+// 파산 변경, currentProcedureStep 없이 호출)과 문자 발송에 적용 — PATCH /v1/analysis/{id}가 절차
+// 자체를 바꾸는 요청은 계약대기중부터도 허용하기 때문.
 export const DIAGNOSIS_PROCEDURE_GUIDE_UNLOCKED_STATUSES: readonly AnalysisStatus[] = [
   "contract_pending",
   "in_progress",
   "suspended",
+];
+
+// "현재 단계로 설정"(currentProcedureStep 지정) 전용 잠금 기준. 실 API 스펙상 PATCH
+// /v1/analysis/{id}의 절차 진행 단계 업데이트는 절차진행중(in_progress) 상태에서만 허용된다 —
+// 위 GUIDE_UNLOCKED_STATUSES보다 좁다(contract_pending/suspended 제외).
+export const DIAGNOSIS_PROCEDURE_STEP_UNLOCKED_STATUSES: readonly AnalysisStatus[] = [
+  "in_progress",
 ];
 
 // ── 추천 절차 ────────────────────────────────────────────────
@@ -62,6 +71,13 @@ export type DiagnosisListItem = {
   feePlanSummary: FeePlanSummary | null;
   progressStep: number; // 절차 안내 진행 단계 (1-based). 아직 추적 시작 전이면 1
   isShared: boolean; // 공유(납품) 관련 건 여부 — 삭제 가능 여부 등에 사용. 고객 연결 여부와는 다름(isCustomerConnected 참고)
+  // 공유 연결 상태. delivered=공유중, rejected=반려됨, revoked=철회됨. 연결 없으면 null.
+  deliveryStatus?: "delivered" | "revoked" | "rejected" | null;
+  // 과거에 공유한 적 있는 건이면 채워짐 — 재공유 시 동일 프로젝트로 제한하는 데 사용
+  // (AnalysisShareModal의 lockedPartner). partnerId는 공유 API 호출 시 그대로 사용.
+  lawyerProjectId?: number | null;
+  lawyerProjectName?: string | null;
+  partnerId?: number | null;
   // 고객과 연결되어 있는지 여부. 목록의 체인 아이콘 노출 조건 — isShared와 혼동 금지.
   isCustomerConnected: boolean;
   consultedAt: string; // ISO 날짜 (YYYY-MM-DD)
@@ -74,9 +90,13 @@ export type DiagnosisListItem = {
   rejectionReason?: string | null;
 };
 
-// 목록 테이블 "진행단계" 셀용. 상세 API의 procedureGuides가 목록에는 없어
-// 절차별 고정 단계명을 클라이언트에서 참조한다. (개인회생 9단계는 기존 mock/피그마와 동일)
-export const PROCEDURE_PROGRESS_STEP_TITLES: Record<RecommendedProcedure, readonly string[]> = {
+export type ProcedureStepTitlesByProcedure = Record<RecommendedProcedure, readonly string[]>;
+
+// 목록 테이블 "진행단계" 셀용 폴백. 상세 API의 procedureGuides가 목록에는 없어 절차별 단계명이
+// 필요한데, 실 마스터 데이터(GET /v1/analysis/procedures, useAnalysisProcedureMaster)가 아직
+// 로딩 전이거나 실패했을 때만 이 값을 쓴다 — 정상 상황에선 마스터 데이터가 우선한다.
+// (개인회생 9단계는 기존 mock/피그마 값 — 실 API와 단계 수가 다를 수 있음을 감안한 방어값.)
+export const PROCEDURE_PROGRESS_STEP_TITLES: ProcedureStepTitlesByProcedure = {
   individual_rehab: [
     "신청 전 상담",
     "신청서 작성 및 접수",
@@ -88,18 +108,18 @@ export const PROCEDURE_PROGRESS_STEP_TITLES: Record<RecommendedProcedure, readon
     "변제 수행",
     "면책결정",
   ],
-  // 채무조정·파산은 상세 guides가 우선. 목록용 폴백(단계 수·명칭은 백엔드 guides와 달라질 수 있음).
   debt_adjustment: ["상담·접수", "신청", "심사", "확정", "상환 이행", "완료"],
   bankruptcy: ["신청 전 상담", "신청서 접수", "파산선고", "면책심문", "면책결정", "종료"],
 };
 
 export function getProgressStepMeta(
   procedure: RecommendedProcedure | undefined,
-  step: number
+  step: number,
+  stepTitlesByProcedure: ProcedureStepTitlesByProcedure = PROCEDURE_PROGRESS_STEP_TITLES
 ): { current: number; total: number; title: string } {
   // 분석이 아직 완료되지 않았거나(추천 절차 미확정) 백엔드가 알 수 없는 값을 내려주면
   // procedure가 없을 수 있다 — 목록 전체가 죽지 않도록 방어적으로 처리.
-  const titles = procedure ? PROCEDURE_PROGRESS_STEP_TITLES[procedure] : undefined;
+  const titles = procedure ? stepTitlesByProcedure[procedure] : undefined;
   if (!titles || titles.length === 0) {
     return { current: 1, total: 1, title: "확인 중" };
   }
@@ -109,9 +129,16 @@ export function getProgressStepMeta(
 }
 
 // 절차진행중 상태뱃지에 붙는 "현재/총단계" (예: "5/9"). 총단계를 모르면 생략.
-export function resolveInProgressStepLabel(item: DiagnosisListItem): string | undefined {
+export function resolveInProgressStepLabel(
+  item: DiagnosisListItem,
+  stepTitlesByProcedure?: ProcedureStepTitlesByProcedure
+): string | undefined {
   if (item.status !== "in_progress") return undefined;
-  const { current, total } = getProgressStepMeta(item.recommendedProcedure, item.progressStep);
+  const { current, total } = getProgressStepMeta(
+    item.recommendedProcedure,
+    item.progressStep,
+    stepTitlesByProcedure
+  );
   return total > 1 ? `${current}/${total}` : undefined;
 }
 
@@ -551,7 +578,9 @@ export type DiagnosisMessageType =
   | "reject"
   | "accept"
   | "fee_create"
-  | "fee_update";
+  | "fee_update"
+  | "fee_stop"
+  | "fee_refund";
 
 export type DiagnosisMessage = {
   type: DiagnosisMessageType;


### PR DESCRIPTION
- 진단 목록 상단 요약 카드(SummaryCards)를 375px 모바일 Figma 스펙에 맞춰 재정비 (그리드 1/2/4열 분기, 카드 높이 96px 제한+스크롤, 타이포·간격 축소, 금액 만원 단위 축약)
- 절차 전환(트래킹 절차 변경)과 "현재 단계로 설정"의 상태 게이트를 분리 — 전자는 계약대기중부터, 후자는 절차진행중부터만 허용(실 API 스펙 기준)
- 재공유 시 프로젝트 선택 단계를 건너뛰고 기존 파트너로 고정(AnalysisShareModal)
- 분석 공유 시 참고사항 전송 필드명을 실 API 기준(referenceNote → message)으로 수정
- 전달사항 타임라인에 수임료 중단/환불 메시지 타입 추가, 모바일 팝업으로 분리 노출
- 절차 마스터 데이터를 하드코딩 대신 GET /v1/analysis/procedures로 연동 (staleTime 24h — 토큰 생명주기와 동일하게 캐싱)
- 진단 목록 occupation(직업) 매핑 누락 수정 — 항상 "무직"으로 표기되던 문제
- 수임료 결제 정보 모달: 회차 체크 시 모달 폭이 흔들리던 문제 수정(입력 영역 폭 고정)
- "정보수정"은 상담중/반려된 건만 가능하도록 상태 가드 + 안내 모달 추가
- 신규/수정 진단 폼 "기타사항" 스텝의 모바일 닫기(X) 버튼 위치를 타이틀 행으로 재배치
- 다크모드 OS 자동감지(prefers-color-scheme) 제거, 미설정 시 라이트 기본값 고정
- ErrorFeedbackModalProvider 아이콘 SVG 속성 오타(stroke-width 등) 수정
- 회생·파산 Analysis API 연동 현황 및 QA 체크리스트 문서 추가