### PR TITLE
fix: 채무 입력값 검증 강화 및 결과 상세 UI 조정

### DIFF
--- a/src/components/debt-relief/form/DiagnosisFormContent.tsx
+++ b/src/components/debt-relief/form/DiagnosisFormContent.tsx
@@ -14,6 +14,7 @@ import {
   isDiagnosisFormComplete,
   isDiagnosisFormDirty,
   isDiagnosisStepComplete,
+  isRecentAndSecuredDebtOverTotal,
 } from "./validateDiagnosisForm";
 import { FORM_STEPS } from "./steps";
 import FormSidebar from "./FormSidebar";
@@ -33,6 +34,10 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
   const [projectId, ready] = useSelectedProjectId();
   const { form, setForm, update, derived } = useDiagnosisForm();
   const [analyzing, setAnalyzing] = useState(false);
+  // 분석하기 클릭 시 담보부채무·최근 3개월/1년 내 채무액 합이 총 채무 합계를 초과한 적이 있으면
+  // true로 래치. Step3Debts가 이 값과 최신 폼 상태를 함께 계산해 여전히 초과 상태일 때만 필드
+  // 테두리를 빨갛게 표시하고, 값이 다시 유효해지는 즉시(재계산 결과 false) 자동으로 해제된다.
+  const [debtSumOverLimitChecked, setDebtSumOverLimitChecked] = useState(false);
 
   const isEdit = Boolean(diagnosisId);
   const [loadingForm, setLoadingForm] = useState(isEdit);
@@ -185,6 +190,20 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
       return;
     }
 
+    if (isRecentAndSecuredDebtOverTotal(form, derived.totalDebtManwon)) {
+      setDebtSumOverLimitChecked(true);
+      showErrorModal({
+        type: "info",
+        title: "알림",
+        headline: "채무 금액을 다시 확인해주세요.",
+        description: "담보부채무·최근 3개월/1년 내 채무액의 합이 총 채무 합계를 초과할 수 없습니다.",
+        confirmText: "채무 현황 입력",
+        hideCancel: true,
+        onConfirm: () => goToStep(2),
+      });
+      return;
+    }
+
     // 재분석(수정 모드)은 성공 시 상태/절차/현재단계가 초기화되고 AI 채팅 이력이 삭제되는
     // 되돌릴 수 없는 부수효과가 있어 확인을 먼저 받는다. 신규 생성은 잃을 기존 상태가 없어 대상 아님.
     if (isEdit) {
@@ -233,7 +252,14 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
       case "assets":
         return <Step2Assets form={form} update={update} />;
       case "debts":
-        return <Step3Debts form={form} update={update} derived={derived} />;
+        return (
+          <Step3Debts
+            form={form}
+            update={update}
+            derived={derived}
+            debtSumOverLimitChecked={debtSumOverLimitChecked}
+          />
+        );
       case "income":
         return <Step4IncomeExpense form={form} update={update} derived={derived} />;
       case "others":

--- a/src/components/debt-relief/form/FormControls.tsx
+++ b/src/components/debt-relief/form/FormControls.tsx
@@ -75,15 +75,24 @@ export function TextInput({
   );
 }
 
+// 최대 9자리(999,999,999만원 = 약 10조원) — 이보다 길면 Number.MAX_SAFE_INTEGER를 넘어
+// parseInt 결과가 부정확해지고 toLocaleString 표시가 깨진다. 개인 채무/자산 입력 범위로는
+// 충분히 넉넉해 실사용에는 제약이 되지 않는다.
+const MANWON_MAX_DIGITS = 9;
+
 // 만원 단위 숫자 입력. 값은 콤마 포맷, 우측에 "만원" 접미사
 export function ManwonInput({
   value,
   onChange,
   placeholder = "0",
+  invalid = false,
 }: {
   value: number;
   onChange: (value: number) => void;
   placeholder?: string;
+  // true면 border를 danger 색으로 표시 (예: 제출 시점에 발견된 채무 금액 합계 초과).
+  // 호출부에서 값이 다시 유효해지는 순간 false로 넘겨주면 즉시 해제된다.
+  invalid?: boolean;
 }) {
   return (
     <div className="relative">
@@ -91,11 +100,11 @@ export function ManwonInput({
         inputMode="numeric"
         value={value ? value.toLocaleString("ko-KR") : ""}
         onChange={(e) => {
-          const digits = e.target.value.replace(/[^0-9]/g, "");
+          const digits = e.target.value.replace(/[^0-9]/g, "").slice(0, MANWON_MAX_DIGITS);
           onChange(digits ? parseInt(digits, 10) : 0);
         }}
         placeholder={placeholder}
-        className={`${INPUT_CLASS} pr-12`}
+        className={`${INPUT_CLASS} pr-12 ${invalid ? "!border-danger-40 dark:!border-danger-40" : ""}`}
       />
       <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[14px] font-medium tracking-[-0.02em] text-neutral-60 pointer-events-none">
         만원

--- a/src/components/debt-relief/form/Step3Debts.tsx
+++ b/src/components/debt-relief/form/Step3Debts.tsx
@@ -11,11 +11,15 @@ import {
 import { FormField, FormSectionTitle, ManwonInput } from "./FormControls";
 import { PillSelect, PillMultiSelect } from "./PillSelect";
 import { FormToggleRow } from "./FormToggle";
+import { getOverLimitDebtFields } from "./validateDiagnosisForm";
 
 type Props = {
   form: DiagnosisFormState;
   update: <K extends keyof DiagnosisFormState>(key: K, value: DiagnosisFormState[K]) => void;
   derived: DiagnosisDerivedValues;
+  // 분석하기 제출 시점에 담보부채무·최근 3개월/1년 내 채무액의 합이 총 채무 합계를 초과한 적이
+  // 있으면 true. 이후 값이 다시 유효해지면(sum <= totalDebt) 매 렌더마다 재계산되어 즉시 해제된다.
+  debtSumOverLimitChecked?: boolean;
 };
 
 function getDebtAmountFields(selectedTypes: DebtType[]): { key: DebtType; label: string }[] {
@@ -24,7 +28,13 @@ function getDebtAmountFields(selectedTypes: DebtType[]): { key: DebtType; label:
   );
 }
 
-export default function Step3Debts({ form, update, derived }: Props) {
+export default function Step3Debts({ form, update, derived, debtSumOverLimitChecked = false }: Props) {
+  // 값 하나만으로 총 채무를 넘는 필드가 있으면 그 필드만 표시하고, 여러 필드의 조합으로만
+  // 초과하는 경우(원인을 특정할 수 없음)에는 세 필드 모두 표시한다 — getOverLimitDebtFields 참고.
+  const overLimitFields = debtSumOverLimitChecked
+    ? getOverLimitDebtFields(form, derived.totalDebtManwon)
+    : [];
+
   const setAmount = (type: DebtType, value: number) => {
     update("debtAmounts", { ...form.debtAmounts, [type]: value });
   };
@@ -115,18 +125,21 @@ export default function Step3Debts({ form, update, derived }: Props) {
               <ManwonInput
                 value={form.recentDebtWithin3Months}
                 onChange={(value) => update("recentDebtWithin3Months", value)}
+                invalid={overLimitFields.includes("recentDebtWithin3Months")}
               />
             </FormField>
             <FormField label="최근 1년 내 채무액" filled={form.recentDebtWithin1Year > 0}>
               <ManwonInput
                 value={form.recentDebtWithin1Year}
                 onChange={(value) => update("recentDebtWithin1Year", value)}
+                invalid={overLimitFields.includes("recentDebtWithin1Year")}
               />
             </FormField>
             <FormField label="담보부채무" filled={form.securedDebt > 0}>
               <ManwonInput
                 value={form.securedDebt}
                 onChange={(value) => update("securedDebt", value)}
+                invalid={overLimitFields.includes("securedDebt")}
               />
             </FormField>
           </div>

--- a/src/components/debt-relief/form/validateDiagnosisForm.ts
+++ b/src/components/debt-relief/form/validateDiagnosisForm.ts
@@ -64,6 +64,41 @@ export function getMissingRequiredFieldLabelsForStep(
   }
 }
 
+/** 담보부채무·최근 3개월/1년 내 채무액 합이 총 채무 합계(채무종류별 금액 합)를 넘는지 검사 */
+export function isRecentAndSecuredDebtOverTotal(
+  form: DiagnosisFormState,
+  totalDebtManwon: number
+): boolean {
+  const sum = form.securedDebt + form.recentDebtWithin3Months + form.recentDebtWithin1Year;
+  return sum > totalDebtManwon;
+}
+
+export type OverLimitDebtField = "securedDebt" | "recentDebtWithin3Months" | "recentDebtWithin1Year";
+
+/**
+ * 합계 초과 시 어떤 필드가 원인인지 최대한 특정한다. 한 필드의 값만으로도 총 채무를 넘는다면
+ * (다른 두 필드가 0이어도 초과) 그 필드가 명백한 원인이므로 해당 필드만 반환한다.
+ * 여러 필드가 함께 더해져야만 초과하는 조합이면 수학적으로 "범인"을 특정할 수 없으므로
+ * 세 필드 모두 반환한다(기존 동작 유지). 초과하지 않으면 빈 배열.
+ */
+export function getOverLimitDebtFields(
+  form: DiagnosisFormState,
+  totalDebtManwon: number
+): OverLimitDebtField[] {
+  if (!isRecentAndSecuredDebtOverTotal(form, totalDebtManwon)) return [];
+
+  const fields: { key: OverLimitDebtField; value: number }[] = [
+    { key: "securedDebt", value: form.securedDebt },
+    { key: "recentDebtWithin3Months", value: form.recentDebtWithin3Months },
+    { key: "recentDebtWithin1Year", value: form.recentDebtWithin1Year },
+  ];
+  const individuallyOverLimit = fields
+    .filter((field) => field.value > totalDebtManwon)
+    .map((field) => field.key);
+
+  return individuallyOverLimit.length > 0 ? individuallyOverLimit : fields.map((field) => field.key);
+}
+
 export function isDiagnosisFormComplete(form: DiagnosisFormState): boolean {
   return getMissingRequiredFieldLabels(form).length === 0;
 }

--- a/src/components/debt-relief/result/DiagnosisCustomerInfoModal.tsx
+++ b/src/components/debt-relief/result/DiagnosisCustomerInfoModal.tsx
@@ -271,13 +271,13 @@ function buildSections(input: AnalysisInputData, contact: string | null | undefi
     { label: "성별", value: input.gender === "female" ? "여" : input.gender === "male" ? "남" : "-" },
     { label: "연령대", value: input.ageGroup || "-" },
     { label: "휴대폰번호", value: phone },
-    { label: "고용형태", value: input.employmentType || "-" },
     { label: "부양가족", value: formatDependents(input.dependents) },
     { label: "배우자 소득", value: yesNo(input.hasSpouseIncome) },
   ];
 
   const assetRows: DisplayRow[] = [
     { label: "부동산 보유여부", value: realEstateOwnershipLabel(input.realEstateBreakdown) },
+    { label: "자가 소유 시가", value: formatManwon(input.totalRealEstateValue) },
     {
       label: "금융자산",
       value: optionLabel(
@@ -321,6 +321,7 @@ function buildSections(input: AnalysisInputData, contact: string | null | undefi
         INCOME_FROM[input.monthlyIncomeRange] ?? input.monthlyIncomeRange
       ),
     },
+    { label: "고용형태", value: input.employmentType || "-" },
     {
       label: "주거형태",
       value: optionLabel(HOUSING_TYPE_OPTIONS, input.housingType),
@@ -347,9 +348,9 @@ function buildSections(input: AnalysisInputData, contact: string | null | undefi
 
   // 1열(모바일·태블릿)에서는 지출 항목을 가용소득 앞에 모아 자연스럽게 읽히도록 함
   const incomeRows: DisplayRow[] = [
-    ...incomeLeftRows.slice(0, 4),
+    ...incomeLeftRows.slice(0, -1),
     ...incomeRightRows,
-    incomeLeftRows[4],
+    incomeLeftRows[incomeLeftRows.length - 1],
   ];
 
   const otherRows: DisplayRow[] = [

--- a/src/components/debt-relief/result/SectionAiRecommendation.tsx
+++ b/src/components/debt-relief/result/SectionAiRecommendation.tsx
@@ -106,7 +106,7 @@ export default function SectionAiRecommendation({
       <div className="hidden lg:block">
         <div className="rounded-[12px] bg-neutral-10 px-10 py-6 dark:bg-neutral-20">
           <div className="flex items-center justify-between gap-10">
-            <div className="min-w-0 flex-1 max-w-[581px]">
+            <div className="min-w-0 flex-1 max-w-[800px]">
               <div className="flex h-6 items-center">
                 <p className="inline-flex h-5 items-center text-[16px] font-medium leading-5 tracking-[-0.04em] text-neutral-60">
                   AI 분석 추천
@@ -128,7 +128,7 @@ export default function SectionAiRecommendation({
                 <h3 className="shrink-0 text-[36px] font-extrabold leading-[43px] tracking-[-0.04em] text-neutral-90">
                   {recommendation.title}
                 </h3>
-                <p className="min-w-0 w-[392px] max-w-[392px] shrink-0 text-[14px] font-medium leading-5 tracking-[-0.02em] text-neutral-90 whitespace-pre-line">
+                <p className="min-w-0 w-[690px] max-w-[690px] shrink-0 text-[14px] font-medium leading-5 tracking-[-0.02em] text-neutral-90 whitespace-pre-line">
                   {recommendation.description}
                 </p>
               </div>


### PR DESCRIPTION
- ManwonInput 자릿수를 9자리로 제한해 과도한 입력 시 부동소수점 정밀도 깨짐 방지
- 담보부채무·최근 3개월/1년 내 채무액 합이 총 채무 합계를 초과하면 분석하기 제출 시 안내 모달 노출. 단일 필드 값만으로 총 채무를 넘는 경우 그 필드만 빨간 테두리로 특정하고, 여러 필드의 조합으로만 초과하는 경우(원인 특정 불가)에는 세 필드 모두 표시하며, 값이 다시 유효해지는 즉시 재제출 없이 테두리가 해제됨
- 고객정보 모달: 부동산 시가 행 추가, 고용형태 표시 순서 조정
- AI 분석 추천 설명 영역 폭 확장