### PR TITLE
fix: 날짜/월 선택기 선택 셀 다크모드 가독성 수정

### DIFF
--- a/src/components/common/DatePicker.tsx
+++ b/src/components/common/DatePicker.tsx
@@ -32,6 +32,12 @@ const MONTHS = Array.from({ length: 12 }, (_, idx) => idx);
 /** day: 일 선택 / month: 월 선택 / year: 연도 선택 */
 type DatePickerMode = "day" | "month" | "year";
 
+/**
+ * 선택된 셀 스타일. 배경이 라이트/다크 공통으로 밝은 민트라 글자색도 테마와 무관하게
+ * 어둡게 고정한다(다크모드에서 밝은 글자가 배경에 묻히는 것을 방지).
+ */
+const SELECTED_CELL_CLS = "bg-[#D6FAE8] !text-[#252525]";
+
 /** minDate가 없을 때 연도 선택 목록이 거슬러 올라가는 하한(고령 고객 생년월일까지 커버) */
 const EARLIEST_SELECTABLE_YEAR = 1920;
 /** maxDate가 없을 때 연도 선택 목록이 나아가는 기본 범위 */
@@ -368,7 +374,7 @@ export default function DatePicker(props: DatePickerProps) {
 										"w-8 h-8 flex items-center justify-center rounded-full text-[14px]";
 									const textCls = inCurrent ? "text-[#252525] dark:text-neutral-80" : "text-[#B0B0B0] dark:text-neutral-60";
 									const selectedCls = isSelected
-										? "bg-[#D6FAE8] dark:!text-neutral-20 dark:bg-primary-40/30 hover:bg-[#D6FAE8] dark:hover:bg-primary-40/30"
+										? `${SELECTED_CELL_CLS} hover:bg-[#D6FAE8]`
 										: "hover:bg-neutral-20 dark:hover:bg-neutral-30";
 									const disabledCls = isDisabled ? "opacity-30 cursor-not-allowed" : "cursor-pointer";
 									
@@ -418,7 +424,7 @@ export default function DatePicker(props: DatePickerProps) {
 											isDisabled
 												? "opacity-30 cursor-not-allowed text-[#B0B0B0] dark:text-neutral-60"
 												: isCurrentMonth
-													? "bg-[#D6FAE8] dark:bg-primary-40/30 text-[#252525] dark:text-neutral-80 font-medium cursor-pointer"
+													? `${SELECTED_CELL_CLS} font-medium cursor-pointer`
 													: "text-[#252525] dark:text-neutral-80 hover:bg-neutral-20 dark:hover:bg-neutral-30 cursor-pointer"
 										}`}
 									>
@@ -445,7 +451,7 @@ export default function DatePicker(props: DatePickerProps) {
 												isDisabled 
 													? "opacity-30 cursor-not-allowed text-[#B0B0B0] dark:text-neutral-60"
 													: isCurrentYear 
-														? "bg-[#D6FAE8] dark:bg-primary-40/30 text-[#252525] dark:text-neutral-80 font-medium cursor-pointer" 
+														? `${SELECTED_CELL_CLS} font-medium cursor-pointer` 
 														: "text-[#252525] dark:text-neutral-80 hover:bg-neutral-20 dark:hover:bg-neutral-30 cursor-pointer"
 											}`}
 											style={{ fontFamily: "var(--font-montserrat)" }}

--- a/src/components/common/MonthPicker.tsx
+++ b/src/components/common/MonthPicker.tsx
@@ -13,6 +13,9 @@ type MonthPickerProps = {
     dateFormat?: string;
 };
 
+/** 선택된 셀 스타일. 배경이 라이트/다크 공통이라 글자색도 테마와 무관하게 어둡게 고정한다(DatePicker와 동일). */
+const SELECTED_CELL_CLS = "bg-[#D6FAE8] !text-[#252525]";
+
 export default function MonthPicker(props: MonthPickerProps) {
 	const { value, onChange, placeholder = "연도 . 월", className = "", disabled, minDate, maxDate, dateFormat = "yyyy. MM" } = props;
 
@@ -246,7 +249,7 @@ export default function MonthPicker(props: MonthPickerProps) {
 										type="button"
 										onClick={() => !isDisabled && onSelectMonth(i)}
 										className={`h-10 rounded-[6px] text-[14px] flex items-center justify-center transition-colors
-                                            ${isSelected ? "bg-[#D6FAE8] dark:!text-neutral-20 dark:bg-primary-40/30 text-[#252525] dark:text-neutral-80" : "text-[#252525] dark:text-neutral-80 hover:bg-neutral-20 dark:hover:bg-neutral-30"}
+                                            ${isSelected ? SELECTED_CELL_CLS : "text-[#252525] dark:text-neutral-80 hover:bg-neutral-20 dark:hover:bg-neutral-30"}
                                             ${isDisabled ? "opacity-30 cursor-not-allowed" : "cursor-pointer"}
                                         `}
 										style={{ fontFamily: "var(--font-montserrat)" }}
@@ -271,7 +274,7 @@ export default function MonthPicker(props: MonthPickerProps) {
 											onClick={() => onSelectYear(y)}
 											className={`h-8 rounded-[6px] text-[14px] flex items-center justify-center cursor-pointer ${
 												isSelected || isCurrentYear
-													? "bg-[#D6FAE8] dark:bg-primary-40/30 text-[#252525] dark:text-neutral-80 font-medium"
+													? `${SELECTED_CELL_CLS} font-medium`
 													: "text-[#252525] dark:text-neutral-80 hover:bg-neutral-20 dark:hover:bg-neutral-30"
 											}`}
 											style={{ fontFamily: "var(--font-montserrat)" }}


### PR DESCRIPTION
다크모드에서 선택된 연도·월 셀의 글자가 배경에 묻혀 읽히지 않았다.
원인은 dark:bg-primary-40/30이 실제로는 아무 CSS도 만들지 않는 것 — bg-primary-40은 @utility로 정의돼 있어 /30 투명도 수식어를 지원하지 않고 (투명도 변형은 bg-primary-10/xx만 평문 CSS로 정의됨), --color-primary-40도 테마 토큰에 없어 자동 생성되지 않는다. 그래서 다크모드에서도 배경은 밝은
민트로 남는데 글자만 dark:text-neutral-80(밝은 회색)으로 바뀌어 있었다.

선택 셀 배경이 테마 공통이므로 글자색도 테마와 무관하게 어둡게 고정한다.
죽은 dark:bg-primary-40/30 클래스는 제거.