### PR TITLE
feat: 고객목록 전체선택 벌크 액션에 경고 모달 통일 적용

### DIFF
--- a/src/components/customers/CustomersActions.tsx
+++ b/src/components/customers/CustomersActions.tsx
@@ -259,16 +259,51 @@ export default function CustomersActions({
 
   const hasSelection = selectedIds.length > 0 || selectionMode === "all";
 
-  const deleteCount = selectionMode === "all" ? total : selectedIds.length;
+  // 모든 벌크 액션이 동일한 선택 범위를 대상으로 한다 — 페이지 한도(limit)를 넘으면
+  // 여러 페이지에 걸친 "전체 선택"이라 눈으로 다 확인하지 못한 채 실행될 위험이 커진다.
+  const bulkTargetCount = selectionMode === "all" ? total : selectedIds.length;
+  const OVER_LIMIT_CONFIRM_DELAY_SECONDS = 3;
+
+  /**
+   * 선택 범위가 현재 페이지 표시 한도를 넘을 때만(=전체선택으로 여러 페이지에 걸친 대상)
+   * "전체 N건에 적용됩니다" 경고 + 3초 카운트다운 확인을 거치게 한다. 한 페이지 안에서
+   * 눈으로 확인 가능한 선택이면 곧바로 진행한다. 직원배정/파트너배정/문자전송/일정추가/
+   * 카테고리 변경이 공유하는 단일 게이트.
+   */
+  const confirmBulkActionIfNeeded = (proceed: () => void) => {
+    if (bulkTargetCount <= limit) {
+      proceed();
+      return;
+    }
+    showConfirmModal({
+      type: "caution",
+      title: "전체 선택",
+      headline: `전체 ${bulkTargetCount.toLocaleString()}건 항목에 적용됩니다.`,
+      message: "계속 진행하시겠습니까?",
+      confirmText: "확인",
+      cancelText: "취소",
+      confirmDelaySeconds: OVER_LIMIT_CONFIRM_DELAY_SECONDS,
+      onConfirm: proceed,
+    });
+  };
+
+  const handleAssignClick = () => confirmBulkActionIfNeeded(onAssignOpen);
+  const handlePartnerAssignClick = () => confirmBulkActionIfNeeded(() => setShareModalOpen(true));
+  const handleSmsClick = () => confirmBulkActionIfNeeded(onSmsOpen);
+  const handleBulkScheduleClick = () => confirmBulkActionIfNeeded(onBulkScheduleOpen);
 
   const handleBulkDelete = () => {
     showConfirmModal({
       title: "고객 삭제",
-      headline: `선택한 ${deleteCount}명의 고객을 삭제하시겠습니까?`,
+      headline: `선택한 ${bulkTargetCount}명의 고객을 삭제하시겠습니까?`,
       message: "삭제된 고객 정보는 복구할 수 없습니다.",
       type: "warning",
       confirmText: "삭제",
       cancelText: "취소",
+      // 전체선택으로 페이지 한도를 넘는 대량 삭제일 때만 카운트다운을 더한다 — 소수 선택
+      // 삭제는 기존처럼 즉시 확인 가능해야 한다(불필요한 대기로 일상적 작업을 방해하지 않음).
+      confirmDelaySeconds:
+        bulkTargetCount > limit ? OVER_LIMIT_CONFIRM_DELAY_SECONDS : undefined,
       onConfirm: async () => {
         try {
           if (selectionMode === "all") {
@@ -300,24 +335,7 @@ export default function CustomersActions({
     });
   };
 
-  const categoryTargetCount = selectionMode === "all" ? total : selectedIds.length;
-
-  /** 한 페이지 분량을 넘게 선택했으면 적용 대상 건수를 먼저 확인받은 뒤 변경 모달을 연다 */
-  const handleCategoryClick = () => {
-    if (categoryTargetCount > limit) {
-      showConfirmModal({
-        type: "caution",
-        title: "전체 선택",
-        headline: `전체 ${categoryTargetCount.toLocaleString()}건 항목에 적용됩니다.`,
-        message: "계속 진행하시겠습니까?",
-        confirmText: "확인",
-        cancelText: "취소",
-        onConfirm: () => setCategoryModalOpen(true),
-      });
-      return;
-    }
-    setCategoryModalOpen(true);
-  };
+  const handleCategoryClick = () => confirmBulkActionIfNeeded(() => setCategoryModalOpen(true));
 
   const iconOnlyButtonClass =
     "cursor-pointer h-9 w-9 flex items-center justify-center rounded-[8px] bg-neutral-90 text-neutral-20 flex-shrink-0 hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed";
@@ -347,7 +365,7 @@ export default function CustomersActions({
               <button
                 type="button"
                 className={iconOnlyButtonClass}
-                onClick={onAssignOpen}
+                onClick={handleAssignClick}
                 disabled={selectedIds.length === 0 && selectionMode !== "all"}
                 aria-label="직원배정"
               >
@@ -362,7 +380,7 @@ export default function CustomersActions({
                 <button
                   type="button"
                   className={iconOnlyButtonClass}
-                  onClick={() => setShareModalOpen(true)}
+                  onClick={handlePartnerAssignClick}
                   disabled={selectedIds.length === 0 && selectionMode !== "all"}
                   aria-label="파트너배정"
                 >
@@ -376,7 +394,7 @@ export default function CustomersActions({
               <button
                 type="button"
                 className={iconOnlyButtonClass}
-                onClick={onSmsOpen}
+                onClick={handleSmsClick}
                 disabled={selectedIds.length === 0 && selectionMode !== "all"}
                 aria-label="문자전송"
               >
@@ -389,7 +407,7 @@ export default function CustomersActions({
               <button
                 type="button"
                 className={iconOnlyButtonClass}
-                onClick={onBulkScheduleOpen}
+                onClick={handleBulkScheduleClick}
                 disabled={selectedIds.length === 0 && selectionMode !== "all"}
                 aria-label="일정추가"
               >
@@ -499,7 +517,7 @@ export default function CustomersActions({
           <button
             type="button"
             className="cursor-pointer h-[34px] px-3 rounded-[5px] bg-neutral-90 dark:bg-neutral-90 text-neutral-20 dark:text-neutral-25 text-[14px] font-semibold tracking-[-0.02em] inline-flex items-center justify-center gap-2 hover:opacity-90 dark:hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:opacity-50"
-            onClick={onAssignOpen}
+            onClick={handleAssignClick}
             disabled={selectedIds.length === 0 && selectionMode !== "all"}
           >
             <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -512,7 +530,7 @@ export default function CustomersActions({
             <button
               type="button"
               className="cursor-pointer h-[34px] px-3 rounded-[5px] bg-neutral-90 dark:bg-neutral-90 text-neutral-20 dark:text-neutral-25 text-[14px] font-semibold tracking-[-0.02em] inline-flex items-center justify-center gap-2 hover:opacity-90 dark:hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:opacity-50"
-              onClick={() => setShareModalOpen(true)}
+              onClick={handlePartnerAssignClick}
               disabled={selectedIds.length === 0 && selectionMode !== "all"}
             >
               <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -524,7 +542,7 @@ export default function CustomersActions({
           <button
             type="button"
             className="cursor-pointer h-[34px] px-3 rounded-[5px] bg-neutral-90 dark:bg-neutral-90 text-neutral-20 dark:text-neutral-25 text-[14px] font-semibold tracking-[-0.02em] inline-flex items-center justify-center gap-2 hover:opacity-90 dark:hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:opacity-50"
-            onClick={onSmsOpen}
+            onClick={handleSmsClick}
             disabled={selectedIds.length === 0 && selectionMode !== "all"}
           >
             <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className="shrink-0" aria-hidden>
@@ -535,7 +553,7 @@ export default function CustomersActions({
           <button
             type="button"
             className="cursor-pointer h-[34px] px-3 rounded-[5px] bg-neutral-90 dark:bg-neutral-90 text-neutral-20 dark:text-neutral-25 text-[14px] font-semibold tracking-[-0.02em] inline-flex items-center justify-center gap-2 hover:opacity-90 dark:hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:opacity-50"
-            onClick={onBulkScheduleOpen}
+            onClick={handleBulkScheduleClick}
             disabled={selectedIds.length === 0 && selectionMode !== "all"}
           >
             <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className="shrink-0" aria-hidden>

--- a/src/lib/confirmModalEvents.ts
+++ b/src/lib/confirmModalEvents.ts
@@ -9,6 +9,12 @@ export type ConfirmModalCallbacks = {
   type?: ConfirmModalType;
   confirmText?: string;
   cancelText?: string | null;
+  /**
+   * 지정하면 확인 버튼이 이 초만큼 숫자(3,2,1…)를 보여주며 비활성화된다. 카운트다운이
+   * 끝나기 전까지는 확인 버튼뿐 아니라 취소/닫기(X)/바깥 클릭도 전부 막혀 모달을 닫을 수 없다
+   * — 대량 작업(전체 선택 등) 경고를 사용자가 실수로 그냥 지나치지 못하게 하기 위함.
+   */
+  confirmDelaySeconds?: number;
   onConfirm?: () => void | Promise<void>;
   onCancel?: () => void | Promise<void>;
 };

--- a/src/providers/ConfirmModalProvider.tsx
+++ b/src/providers/ConfirmModalProvider.tsx
@@ -22,6 +22,7 @@ type ConfirmModalState = {
   type: ConfirmModalType | undefined;
   confirmText: string;
   cancelText: string | null;
+  confirmDelaySeconds?: number;
   onConfirm?: () => void | Promise<void>;
   onCancel?: () => void | Promise<void>;
 };
@@ -73,14 +74,24 @@ export default function ConfirmModalProvider({
     createInitialState()
   );
   const [confirming, setConfirming] = useState(false);
+  // null이면 카운트다운 없음(기존 동작). 양수면 매초 감소하다 0이 되면 잠금 해제.
+  const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
+  // 카운트다운이 끝나기 전까지는 확인은 물론 취소/닫기(X)/바깥 클릭도 전부 막는다.
+  const isLocked = remainingSeconds !== null && remainingSeconds > 0;
 
   const hide = useCallback(() => {
     setConfirming(false);
+    setRemainingSeconds(null);
     setState(createInitialState());
   }, []);
 
   const show = useCallback((options?: ConfirmModalCallbacks) => {
     setConfirming(false);
+    setRemainingSeconds(
+      options?.confirmDelaySeconds && options.confirmDelaySeconds > 0
+        ? options.confirmDelaySeconds
+        : null
+    );
     setState({
       ...createInitialState(),
       open: true,
@@ -94,10 +105,19 @@ export default function ConfirmModalProvider({
         options?.cancelText === undefined
           ? defaultTexts.cancelText
           : options.cancelText,
+      confirmDelaySeconds: options?.confirmDelaySeconds,
       onConfirm: options?.onConfirm,
       onCancel: options?.onCancel,
     });
   }, []);
+
+  useEffect(() => {
+    if (!state.open || remainingSeconds === null || remainingSeconds <= 0) return;
+    const timer = setTimeout(() => {
+      setRemainingSeconds((prev) => (prev !== null ? prev - 1 : prev));
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [state.open, remainingSeconds]);
 
   useEffect(() => {
     const unsubscribe = subscribeConfirmModal((event) => {
@@ -111,7 +131,7 @@ export default function ConfirmModalProvider({
   }, [show, hide]);
 
   const handleConfirm = useCallback(async () => {
-    if (confirming) return;
+    if (confirming || isLocked) return;
     if (!state.onConfirm) {
       hide();
       return;
@@ -127,9 +147,12 @@ export default function ConfirmModalProvider({
       console.error("ConfirmModal onConfirm failed", err);
       setConfirming(false);
     }
-  }, [confirming, state, hide]);
+  }, [confirming, isLocked, state, hide]);
 
+  // 카운트다운 중에는 취소/닫기(X)/바깥 클릭이 전부 이 함수 하나로 들어오므로,
+  // 여기 한 곳만 막으면 세 경로 모두 막힌다.
   const handleCancel = useCallback(async () => {
+    if (isLocked) return;
     if (state.onCancel) {
       try {
         await state.onCancel();
@@ -138,7 +161,7 @@ export default function ConfirmModalProvider({
       }
     }
     hide();
-  }, [state, hide]);
+  }, [isLocked, state, hide]);
 
   const contextValue = useMemo<ConfirmModalContextValue>(
     () => ({ show, hide }),
@@ -168,8 +191,9 @@ export default function ConfirmModalProvider({
                 ) : null}
                 <button
                   type="button"
-                  className="cursor-pointer h-6 w-6"
+                  className="cursor-pointer h-6 w-6 disabled:cursor-not-allowed disabled:opacity-40"
                   onClick={handleCancel}
+                  disabled={isLocked}
                   aria-label="close confirm modal"
                 >
                   <svg
@@ -311,23 +335,24 @@ export default function ConfirmModalProvider({
               {state.cancelText ? (
                 <button
                   type="button"
-                  className="cursor-pointer flex h-[34px] min-w-[72px] items-center justify-center rounded-[5px] border border-neutral-30 dark:border-neutral-30 px-3 text-[14px] font-semibold tracking-[-0.02em] text-neutral-90 dark:text-neutral-80"
+                  className="cursor-pointer flex h-[34px] min-w-[72px] items-center justify-center rounded-[5px] border border-neutral-30 dark:border-neutral-30 px-3 text-[14px] font-semibold tracking-[-0.02em] text-neutral-90 dark:text-neutral-80 disabled:cursor-not-allowed disabled:opacity-50"
                   onClick={handleCancel}
+                  disabled={isLocked}
                 >
                   {state.cancelText}
                 </button>
               ) : null}
               <button
                 type="button"
-                className={`cursor-pointer flex h-[34px] min-w-[72px] items-center justify-center rounded-[5px] px-3 text-[14px] font-semibold tracking-[-0.02em] disabled:opacity-60 ${
+                className={`cursor-pointer flex h-[34px] min-w-[72px] items-center justify-center rounded-[5px] px-3 text-[14px] font-semibold tracking-[-0.02em] disabled:cursor-not-allowed disabled:opacity-60 ${
                   state.type === "info"
                     ? "bg-secondary-80 dark:bg-secondary-20 text-white"
                     : "bg-neutral-90 dark:bg-neutral-90 text-neutral-40 dark:text-neutral-20"
                 }`}
                 onClick={handleConfirm}
-                disabled={confirming}
+                disabled={confirming || isLocked}
               >
-                {confirming ? "처리 중..." : state.confirmText}
+                {confirming ? "처리 중..." : isLocked ? remainingSeconds : state.confirmText}
               </button>
             </div>
           </div>


### PR DESCRIPTION
카테고리 변경·고객삭제에만 있던 전체선택 경고를 직원배정/파트너배정/문자전송/
일정추가까지 확장하고, 확인 버튼에 3초 카운트다운 잠금(취소/닫기/바깥클릭 차단)을
추가해 실수로 대량 작업을 그냥 지나치지 못하게 함.