### PR TITLE
feat: 고객목록 모바일 벌크 액션을 선택항목 관리 드랍다운으로 통합

### DIFF
--- a/src/components/customers/CustomersActions.tsx
+++ b/src/components/customers/CustomersActions.tsx
@@ -124,8 +124,35 @@ export default function CustomersActions({
   const [excelUploadModalOpen, setExcelUploadModalOpen] = useState(false);
   const [categoryModalOpen, setCategoryModalOpen] = useState(false);
   const [limitPopoverOpen, setLimitPopoverOpen] = useState(false);
+  const [actionsMenuOpen, setActionsMenuOpen] = useState(false);
   const desktopLimitPopoverRef = useRef<HTMLDivElement | null>(null);
   const mobileLimitPopoverRef = useRef<HTMLDivElement | null>(null);
+  const actionsMenuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!actionsMenuOpen) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (!actionsMenuRef.current?.contains(target)) {
+        setActionsMenuOpen(false);
+      }
+    };
+
+    const handleEscapeKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setActionsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscapeKey);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscapeKey);
+    };
+  }, [actionsMenuOpen]);
 
   useEffect(() => {
     if (!limitPopoverOpen) return;
@@ -337,9 +364,6 @@ export default function CustomersActions({
 
   const handleCategoryClick = () => confirmBulkActionIfNeeded(() => setCategoryModalOpen(true));
 
-  const iconOnlyButtonClass =
-    "cursor-pointer h-9 w-9 flex items-center justify-center rounded-[8px] bg-neutral-90 text-neutral-20 flex-shrink-0 hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed";
-
   return (
     <div className="w-full flex justify-between items-start lg:items-center gap-2 lg:gap-3">
       {/* 모바일+태블릿(lg 미만): 좌측 액션 + 우측(삭제/페이지개수), 카운트는 하단 좌측.
@@ -347,91 +371,128 @@ export default function CustomersActions({
           태블릿도 이 컴팩트(아이콘 전용) 레이아웃을 그대로 쓰도록 범위를 넓혔다(2026-07-23). */}
       <div className="lg:hidden w-full flex flex-col gap-2">
         <div className="w-full flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2">
-            <LocalIconTooltip label="고객등록">
+          <div className="flex items-center gap-2 min-w-0">
+            <button
+              type="button"
+              className="cursor-pointer h-[34px] px-3 rounded-[5px] bg-neutral-90 dark:bg-neutral-90 text-neutral-20 dark:text-neutral-25 text-[13px] font-semibold tracking-[-0.02em] inline-flex items-center justify-center gap-1.5 hover:opacity-90 dark:hover:opacity-90 transition-opacity flex-shrink-0"
+              onClick={onCreateOpen}
+            >
+              <svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className="shrink-0" aria-hidden>
+                <path d="M18 10C18 10 14.9526 10 13 10M15.5 12.3333V7.27778M11.3333 6.11111C11.3333 7.82933 9.84095 9.22222 8 9.22222C6.15905 9.22222 4.66667 7.82933 4.66667 6.11111C4.66667 4.39289 6.15905 3 8 3C9.84095 3 11.3333 4.39289 11.3333 6.11111ZM3 16.2222C3 13.6449 5.23858 11.5556 8 11.5556C10.7614 11.5556 13 13.6449 13 16.2222V17H3V16.2222Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              <span>고객등록</span>
+            </button>
+            <div className="relative flex-shrink-0" ref={actionsMenuRef}>
               <button
                 type="button"
-                className={iconOnlyButtonClass}
-                onClick={onCreateOpen}
-                aria-label="고객등록"
+                className="cursor-pointer h-[34px] px-3 rounded-[5px] bg-neutral-90 dark:bg-neutral-90 text-neutral-20 dark:text-neutral-25 text-[13px] font-semibold tracking-[-0.02em] inline-flex items-center justify-center gap-1.5 hover:opacity-90 dark:hover:opacity-90 transition-opacity"
+                onClick={() => setActionsMenuOpen((prev) => !prev)}
+                aria-haspopup="menu"
+                aria-expanded={actionsMenuOpen}
               >
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
-                  <path d="M18 10C18 10 14.9526 10 13 10M15.5 12.3333V7.27778M11.3333 6.11111C11.3333 7.82933 9.84095 9.22222 8 9.22222C6.15905 9.22222 4.66667 7.82933 4.66667 6.11111C4.66667 4.39289 6.15905 3 8 3C9.84095 3 11.3333 4.39289 11.3333 6.11111ZM3 16.2222C3 13.6449 5.23858 11.5556 8 11.5556C10.7614 11.5556 13 13.6449 13 16.2222V17H3V16.2222Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </button>
-            </LocalIconTooltip>
-            {showAssignButton && (
-            <LocalIconTooltip label="직원배정">
-              <button
-                type="button"
-                className={iconOnlyButtonClass}
-                onClick={handleAssignClick}
-                disabled={selectedIds.length === 0 && selectionMode !== "all"}
-                aria-label="직원배정"
-              >
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
-                  <path d="M8.03017 11.1363C7.73727 10.8434 7.2624 10.8434 6.96951 11.1363C6.67661 11.4292 6.67661 11.9041 6.96951 12.197L7.49984 11.6667L8.03017 11.1363ZM9.1665 13.3333L8.63617 13.8637C8.92907 14.1566 9.40394 14.1566 9.69683 13.8637L9.1665 13.3333ZM13.0302 10.5303C13.3231 10.2374 13.3231 9.76256 13.0302 9.46967C12.7373 9.17678 12.2624 9.17678 11.9695 9.46967L12.4998 10L13.0302 10.5303ZM15.8332 5.83333H15.0832V15.8333H15.8332H16.5832V5.83333H15.8332ZM14.1665 17.5V16.75H5.83317V17.5V18.25H14.1665V17.5ZM4.1665 15.8333H4.9165V5.83333H4.1665H3.4165V15.8333H4.1665ZM5.83317 4.16667V4.91667H7.49984V4.16667V3.41667H5.83317V4.16667ZM12.4998 4.16667V4.91667H14.1665V4.16667V3.41667H12.4998V4.16667ZM5.83317 17.5V16.75C5.32691 16.75 4.9165 16.3396 4.9165 15.8333H4.1665H3.4165C3.4165 17.168 4.49848 18.25 5.83317 18.25V17.5ZM15.8332 15.8333H15.0832C15.0832 16.3396 14.6728 16.75 14.1665 16.75V17.5V18.25C15.5012 18.25 16.5832 17.168 16.5832 15.8333H15.8332ZM15.8332 5.83333H16.5832C16.5832 4.49865 15.5012 3.41667 14.1665 3.41667V4.16667V4.91667C14.6728 4.91667 15.0832 5.32707 15.0832 5.83333H15.8332ZM4.1665 5.83333H4.9165C4.9165 5.32707 5.32691 4.91667 5.83317 4.91667V4.16667V3.41667C4.49848 3.41667 3.4165 4.49865 3.4165 5.83333H4.1665ZM7.49984 11.6667L6.96951 12.197L8.63617 13.8637L9.1665 13.3333L9.69683 12.803L8.03017 11.1363L7.49984 11.6667ZM9.1665 13.3333L9.69683 13.8637L13.0302 10.5303L12.4998 10L11.9695 9.46967L8.63617 12.803L9.1665 13.3333ZM9.1665 2.5V3.25H10.8332V2.5V1.75H9.1665V2.5ZM10.8332 5.83333V5.08333H9.1665V5.83333V6.58333H10.8332V5.83333ZM9.1665 5.83333V5.08333C8.66024 5.08333 8.24984 4.67293 8.24984 4.16667H7.49984H6.74984C6.74984 5.50135 7.83182 6.58333 9.1665 6.58333V5.83333ZM12.4998 4.16667H11.7498C11.7498 4.67293 11.3394 5.08333 10.8332 5.08333V5.83333V6.58333C12.1679 6.58333 13.2498 5.50135 13.2498 4.16667H12.4998ZM10.8332 2.5V3.25C11.3394 3.25 11.7498 3.66041 11.7498 4.16667H12.4998H13.2498C13.2498 2.83198 12.1679 1.75 10.8332 1.75V2.5ZM9.1665 2.5V1.75C7.83182 1.75 6.74984 2.83198 6.74984 4.16667H7.49984H8.24984C8.24984 3.66041 8.66024 3.25 9.1665 3.25V2.5Z" fill="currentColor" />
-                </svg>
-              </button>
-            </LocalIconTooltip>
-            )}
-            {showPartnerAssignButton && (
-              <LocalIconTooltip label="파트너배정">
-                <button
-                  type="button"
-                  className={iconOnlyButtonClass}
-                  onClick={handlePartnerAssignClick}
-                  disabled={selectedIds.length === 0 && selectionMode !== "all"}
-                  aria-label="파트너배정"
+                <span>선택항목 관리</span>
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                  className={`shrink-0 transition-transform ${actionsMenuOpen ? "rotate-180" : ""}`}
+                  aria-hidden
                 >
-                  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
-                    <path d="M6.66683 4.16667H5.00016C4.07969 4.16667 3.3335 4.91286 3.3335 5.83333V15.8333C3.3335 16.7538 4.07969 17.5 5.00016 17.5H13.3335C14.254 17.5 15.0002 16.7538 15.0002 15.8333V15M6.66683 4.16667C6.66683 5.08714 7.41302 5.83333 8.3335 5.83333H10.0002C10.9206 5.83333 11.6668 5.08714 11.6668 4.16667M6.66683 4.16667C6.66683 3.24619 7.41302 2.5 8.3335 2.5H10.0002C10.9206 2.5 11.6668 3.24619 11.6668 4.16667M11.6668 4.16667H13.3335C14.254 4.16667 15.0002 4.91286 15.0002 5.83333V8.33333M16.6668 11.6667H8.3335M8.3335 11.6667L10.8335 9.16667M8.3335 11.6667L10.8335 14.1667" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                  </svg>
-                </button>
-              </LocalIconTooltip>
-            )}
-            <LocalIconTooltip label="문자전송">
-              <button
-                type="button"
-                className={iconOnlyButtonClass}
-                onClick={handleSmsClick}
-                disabled={selectedIds.length === 0 && selectionMode !== "all"}
-                aria-label="문자전송"
-              >
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
-                  <path d="M5.83333 6.66665H14.1667M5.83333 9.99998H9.16667M10 16.6666L6.66667 13.3333H4.16667C3.24619 13.3333 2.5 12.5871 2.5 11.6666V4.99998C2.5 4.07951 3.24619 3.33331 4.16667 3.33331H15.8333C16.7538 3.33331 17.5 4.07951 17.5 4.99998V11.6666C17.5 12.5871 16.7538 13.3333 15.8333 13.3333H13.3333L10 16.6666Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M2.5 4.5L6 8L9.5 4.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               </button>
-            </LocalIconTooltip>
-            <LocalIconTooltip label="일정추가">
-              <button
-                type="button"
-                className={iconOnlyButtonClass}
-                onClick={handleBulkScheduleClick}
-                disabled={selectedIds.length === 0 && selectionMode !== "all"}
-                aria-label="일정추가"
-              >
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
-                  <path d="M6.66667 5.83333V2.5M13.3333 5.83333V2.5M5.83333 9.16667H14.1667M4.16667 17.5H15.8333C16.7538 17.5 17.5 16.7538 17.5 15.8333V5.83333C17.5 4.91286 16.7538 4.16667 15.8333 4.16667H4.16667C3.24619 4.16667 2.5 4.91286 2.5 5.83333V15.8333C2.5 16.7538 3.24619 17.5 4.16667 17.5Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </button>
-            </LocalIconTooltip>
-            <LocalIconTooltip label="카테고리">
-              <button
-                type="button"
-                className={iconOnlyButtonClass}
-                onClick={handleCategoryClick}
-                disabled={selectedIds.length === 0 && selectionMode !== "all"}
-                aria-label="카테고리"
-              >
-                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
-                  <path d="M3.33301 5.00016C3.33301 4.07969 4.0792 3.3335 4.99967 3.3335H6.66634C7.58682 3.3335 8.33301 4.07969 8.33301 5.00016V6.66683C8.33301 7.5873 7.58682 8.3335 6.66634 8.3335H4.99967C4.0792 8.3335 3.33301 7.5873 3.33301 6.66683V5.00016Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                  <path d="M11.6663 5.00016C11.6663 4.07969 12.4125 3.3335 13.333 3.3335H14.9997C15.9201 3.3335 16.6663 4.07969 16.6663 5.00016V6.66683C16.6663 7.5873 15.9201 8.3335 14.9997 8.3335H13.333C12.4125 8.3335 11.6663 7.5873 11.6663 6.66683V5.00016Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                  <path d="M3.33301 13.3335C3.33301 12.413 4.0792 11.6668 4.99967 11.6668H6.66634C7.58682 11.6668 8.33301 12.413 8.33301 13.3335V15.0002C8.33301 15.9206 7.58682 16.6668 6.66634 16.6668H4.99967C4.0792 16.6668 3.33301 15.9206 3.33301 15.0002V13.3335Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                  <path d="M11.6663 13.3335C11.6663 12.413 12.4125 11.6668 13.333 11.6668H14.9997C15.9201 11.6668 16.6663 12.413 16.6663 13.3335V15.0002C16.6663 15.9206 15.9201 16.6668 14.9997 16.6668H13.333C12.4125 16.6668 11.6663 15.9206 11.6663 15.0002V13.3335Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
-              </button>
-            </LocalIconTooltip>
+              {actionsMenuOpen && (
+                <div
+                  role="menu"
+                  className="absolute left-0 top-full mt-2 w-[140px] rounded-[8px] bg-neutral-90 dark:bg-neutral-90 shadow-[0px_8px_12px_rgba(9,30,66,0.1)] z-50 overflow-hidden py-1"
+                >
+                  {showAssignButton && (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        setActionsMenuOpen(false);
+                        handleAssignClick();
+                      }}
+                      disabled={selectedIds.length === 0 && selectionMode !== "all"}
+                      className="cursor-pointer w-full flex items-center gap-2 px-3 py-2.5 text-[14px] font-semibold tracking-[-0.02em] text-neutral-20 hover:bg-neutral-80 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                    >
+                      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className="shrink-0" aria-hidden>
+                        <path d="M8.03017 11.1363C7.73727 10.8434 7.2624 10.8434 6.96951 11.1363C6.67661 11.4292 6.67661 11.9041 6.96951 12.197L7.49984 11.6667L8.03017 11.1363ZM9.1665 13.3333L8.63617 13.8637C8.92907 14.1566 9.40394 14.1566 9.69683 13.8637L9.1665 13.3333ZM13.0302 10.5303C13.3231 10.2374 13.3231 9.76256 13.0302 9.46967C12.7373 9.17678 12.2624 9.17678 11.9695 9.46967L12.4998 10L13.0302 10.5303ZM15.8332 5.83333H15.0832V15.8333H15.8332H16.5832V5.83333H15.8332ZM14.1665 17.5V16.75H5.83317V17.5V18.25H14.1665V17.5ZM4.1665 15.8333H4.9165V5.83333H4.1665H3.4165V15.8333H4.1665ZM5.83317 4.16667V4.91667H7.49984V4.16667V3.41667H5.83317V4.16667ZM12.4998 4.16667V4.91667H14.1665V4.16667V3.41667H12.4998V4.16667ZM5.83317 17.5V16.75C5.32691 16.75 4.9165 16.3396 4.9165 15.8333H4.1665H3.4165C3.4165 17.168 4.49848 18.25 5.83317 18.25V17.5ZM15.8332 15.8333H15.0832C15.0832 16.3396 14.6728 16.75 14.1665 16.75V17.5V18.25C15.5012 18.25 16.5832 17.168 16.5832 15.8333H15.8332ZM15.8332 5.83333H16.5832C16.5832 4.49865 15.5012 3.41667 14.1665 3.41667V4.16667V4.91667C14.6728 4.91667 15.0832 5.32707 15.0832 5.83333H15.8332ZM4.1665 5.83333H4.9165C4.9165 5.32707 5.32691 4.91667 5.83317 4.91667V4.16667V3.41667C4.49848 3.41667 3.4165 4.49865 3.4165 5.83333H4.1665ZM7.49984 11.6667L6.96951 12.197L8.63617 13.8637L9.1665 13.3333L9.69683 12.803L8.03017 11.1363L7.49984 11.6667ZM9.1665 13.3333L9.69683 13.8637L13.0302 10.5303L12.4998 10L11.9695 9.46967L8.63617 12.803L9.1665 13.3333ZM9.1665 2.5V3.25H10.8332V2.5V1.75H9.1665V2.5ZM10.8332 5.83333V5.08333H9.1665V5.83333V6.58333H10.8332V5.83333ZM9.1665 5.83333V5.08333C8.66024 5.08333 8.24984 4.67293 8.24984 4.16667H7.49984H6.74984C6.74984 5.50135 7.83182 6.58333 9.1665 6.58333V5.83333ZM12.4998 4.16667H11.7498C11.7498 4.67293 11.3394 5.08333 10.8332 5.08333V5.83333V6.58333C12.1679 6.58333 13.2498 5.50135 13.2498 4.16667H12.4998ZM10.8332 2.5V3.25C11.3394 3.25 11.7498 3.66041 11.7498 4.16667H12.4998H13.2498C13.2498 2.83198 12.1679 1.75 10.8332 1.75V2.5ZM9.1665 2.5V1.75C7.83182 1.75 6.74984 2.83198 6.74984 4.16667H7.49984H8.24984C8.24984 3.66041 8.66024 3.25 9.1665 3.25V2.5Z" fill="currentColor" />
+                      </svg>
+                      <span>직원배정</span>
+                    </button>
+                  )}
+                  {showPartnerAssignButton && (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        setActionsMenuOpen(false);
+                        handlePartnerAssignClick();
+                      }}
+                      disabled={selectedIds.length === 0 && selectionMode !== "all"}
+                      className="cursor-pointer w-full flex items-center gap-2 px-3 py-2.5 text-[14px] font-semibold tracking-[-0.02em] text-neutral-20 hover:bg-neutral-80 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                    >
+                      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className="shrink-0" aria-hidden>
+                        <path d="M6.66683 4.16667H5.00016C4.07969 4.16667 3.3335 4.91286 3.3335 5.83333V15.8333C3.3335 16.7538 4.07969 17.5 5.00016 17.5H13.3335C14.254 17.5 15.0002 16.7538 15.0002 15.8333V15M6.66683 4.16667C6.66683 5.08714 7.41302 5.83333 8.3335 5.83333H10.0002C10.9206 5.83333 11.6668 5.08714 11.6668 4.16667M6.66683 4.16667C6.66683 3.24619 7.41302 2.5 8.3335 2.5H10.0002C10.9206 2.5 11.6668 3.24619 11.6668 4.16667M11.6668 4.16667H13.3335C14.254 4.16667 15.0002 4.91286 15.0002 5.83333V8.33333M16.6668 11.6667H8.3335M8.3335 11.6667L10.8335 9.16667M8.3335 11.6667L10.8335 14.1667" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                      <span>파트너배정</span>
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setActionsMenuOpen(false);
+                      handleSmsClick();
+                    }}
+                    disabled={selectedIds.length === 0 && selectionMode !== "all"}
+                    className="cursor-pointer w-full flex items-center gap-2 px-3 py-2.5 text-[14px] font-semibold tracking-[-0.02em] text-neutral-20 hover:bg-neutral-80 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                  >
+                    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className="shrink-0" aria-hidden>
+                      <path d="M5.83333 6.66665H14.1667M5.83333 9.99998H9.16667M10 16.6666L6.66667 13.3333H4.16667C3.24619 13.3333 2.5 12.5871 2.5 11.6666V4.99998C2.5 4.07951 3.24619 3.33331 4.16667 3.33331H15.8333C16.7538 3.33331 17.5 4.07951 17.5 4.99998V11.6666C17.5 12.5871 16.7538 13.3333 15.8333 13.3333H13.3333L10 16.6666Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                    <span>문자전송</span>
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setActionsMenuOpen(false);
+                      handleBulkScheduleClick();
+                    }}
+                    disabled={selectedIds.length === 0 && selectionMode !== "all"}
+                    className="cursor-pointer w-full flex items-center gap-2 px-3 py-2.5 text-[14px] font-semibold tracking-[-0.02em] text-neutral-20 hover:bg-neutral-80 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                  >
+                    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className="shrink-0" aria-hidden>
+                      <path d="M6.66667 5.83333V2.5M13.3333 5.83333V2.5M5.83333 9.16667H14.1667M4.16667 17.5H15.8333C16.7538 17.5 17.5 16.7538 17.5 15.8333V5.83333C17.5 4.91286 16.7538 4.16667 15.8333 4.16667H4.16667C3.24619 4.16667 2.5 4.91286 2.5 5.83333V15.8333C2.5 16.7538 3.24619 17.5 4.16667 17.5Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                    <span>일정추가</span>
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setActionsMenuOpen(false);
+                      handleCategoryClick();
+                    }}
+                    disabled={selectedIds.length === 0 && selectionMode !== "all"}
+                    className="cursor-pointer w-full flex items-center gap-2 px-3 py-2.5 text-[14px] font-semibold tracking-[-0.02em] text-neutral-20 hover:bg-neutral-80 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                  >
+                    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" className="shrink-0" aria-hidden>
+                      <path d="M3.33301 5.00016C3.33301 4.07969 4.0792 3.3335 4.99967 3.3335H6.66634C7.58682 3.3335 8.33301 4.07969 8.33301 5.00016V6.66683C8.33301 7.5873 7.58682 8.3335 6.66634 8.3335H4.99967C4.0792 8.3335 3.33301 7.5873 3.33301 6.66683V5.00016Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                      <path d="M11.6663 5.00016C11.6663 4.07969 12.4125 3.3335 13.333 3.3335H14.9997C15.9201 3.3335 16.6663 4.07969 16.6663 5.00016V6.66683C16.6663 7.5873 15.9201 8.3335 14.9997 8.3335H13.333C12.4125 8.3335 11.6663 7.5873 11.6663 6.66683V5.00016Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                      <path d="M3.33301 13.3335C3.33301 12.413 4.0792 11.6668 4.99967 11.6668H6.66634C7.58682 11.6668 8.33301 12.413 8.33301 13.3335V15.0002C8.33301 15.9206 7.58682 16.6668 6.66634 16.6668H4.99967C4.0792 16.6668 3.33301 15.9206 3.33301 15.0002V13.3335Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                      <path d="M11.6663 13.3335C11.6663 12.413 12.4125 11.6668 13.333 11.6668H14.9997C15.9201 11.6668 16.6663 12.413 16.6663 13.3335V15.0002C16.6663 15.9206 15.9201 16.6668 14.9997 16.6668H13.333C12.4125 16.6668 11.6663 15.9206 11.6663 15.0002V13.3335Z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                    <span>카테고리</span>
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
           <div className="flex items-center gap-4 flex-shrink-0">
             {showDeleteButton && (


### PR DESCRIPTION
버튼 개수가 늘면서 모바일에서 UI가 깨질 위험이 있어 아이콘 나열 대신
고객등록 + 선택항목 관리(직원배정/파트너배정/문자전송/일정추가/카테고리)
드랍다운 2버튼 구성으로 변경.