### PR TITLE
feat: 새출발기금 상세 입력·담보대출 구분·절차 안내 모달 추가

### DIFF
--- a/src/components/common/DatePicker.tsx
+++ b/src/components/common/DatePicker.tsx
@@ -52,6 +52,27 @@ const EARLIEST_SELECTABLE_YEAR = 1920;
 /** maxDate가 없을 때 연도 선택 목록이 나아가는 기본 범위 */
 const DEFAULT_YEARS_AHEAD = 10;
 
+/**
+ * allowTextInput 타이핑 중 숫자만 뽑아 dateFormat의 구분자(". ", "-" 등)를 그대로 살려
+ * 자릿수가 채워지는 대로 재조립한다. "20220103"처럼 숫자만 입력해도, "2022-01-03"처럼
+ * 구분자를 직접 입력해도 결과는 동일하게 dateFormat 형태로 맞춰진다.
+ * yyyy/MM/dd 순서로만 동작한다 — 현재 코드베이스의 모든 dateFormat이 이 순서를 따른다.
+ */
+function formatDigitsToDatePattern(digits: string, dateFormat: string): string {
+	const yearIdx = dateFormat.indexOf("yyyy");
+	const monthIdx = dateFormat.indexOf("MM");
+	const dayIdx = dateFormat.indexOf("dd");
+	if (yearIdx === -1 || monthIdx === -1 || dayIdx === -1) return digits;
+
+	const separator1 = dateFormat.slice(yearIdx + 4, monthIdx);
+	const separator2 = dateFormat.slice(monthIdx + 2, dayIdx);
+
+	const d = digits.slice(0, 8);
+	if (d.length <= 4) return d;
+	if (d.length <= 6) return `${d.slice(0, 4)}${separator1}${d.slice(4)}`;
+	return `${d.slice(0, 4)}${separator1}${d.slice(4, 6)}${separator2}${d.slice(6, 8)}`;
+}
+
 export default function DatePicker(props: DatePickerProps) {
 	const { value, onChange, placeholder = "연도 . 월 . 일", className = "", disabled, minDate, maxDate, dateFormat = "yyyy. MM. dd", panelOffsetY = 8, invalid = false, id, allowTextInput = false } = props;
 
@@ -123,14 +144,14 @@ export default function DatePicker(props: DatePickerProps) {
 	}, [allowTextInput, value, dateFormat, isEditingText, typedInvalid]);
 
 	function handleTypedChange(e: React.ChangeEvent<HTMLInputElement>) {
-		const next = e.target.value;
+		const digitsOnly = e.target.value.replace(/\D/g, "").slice(0, 8);
+		const next = formatDigitsToDatePattern(digitsOnly, dateFormat);
 		setTypedText(next);
 		setTypedInvalid(false);
 
-		const trimmed = next.trim();
-		if (!trimmed) return; // 지우는 중일 수 있으니 blur 전엔 커밋하지 않는다.
+		if (digitsOnly.length < 8) return; // 8자리(연4+월2+일2)가 다 채워지기 전엔 커밋하지 않는다.
 
-		const parsed = parse(trimmed, dateFormat, new Date());
+		const parsed = parse(next, dateFormat, new Date());
 		if (isValid(parsed) && isWithinAllowedRange(parsed)) {
 			const normalized = new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
 			onChange(normalized);

--- a/src/components/debt-relief/form/DebtHistoryCard.tsx
+++ b/src/components/debt-relief/form/DebtHistoryCard.tsx
@@ -115,8 +115,8 @@ export default function DebtHistoryCard({
 
   return (
     // min-w-0: 상세모드 테이블(가로스크롤)이 flex 조상의 min-content 폭을 밀어올리지 않게
-    <div className="min-w-0 rounded-[14px] border border-neutral-30 overflow-hidden">
-      <div className="flex items-start justify-between gap-4 px-5 md:px-6 py-4 md:py-5 border-b border-neutral-30">
+    <div className="min-w-0 rounded-t-[14px] border-t border-x border-neutral-30 overflow-hidden">
+      <div className="flex items-start justify-between gap-4 px-5 md:px-6 py-4 md:py-5">
         <div className="min-w-0">
           <h3 className="text-[16px] font-bold leading-5 text-foreground">채무내역</h3>
           <p className="mt-1.5 text-[13px] leading-4 text-neutral-60">

--- a/src/components/debt-relief/form/DebtItemsTable.tsx
+++ b/src/components/debt-relief/form/DebtItemsTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import DatePicker from "@/components/common/DatePicker";
-import TrashIcon from "@/components/common/icons/TrashIcon";
+import CalendarInlineIcon from "@/components/common/icons/CalendarInlineIcon";
 import { SelectField } from "@/components/customers/detail/SelectField";
 import { useHorizontalDragScroll } from "@/hooks/useHorizontalDragScroll";
 import { calculateDebtItemAmortization } from "@/services/debtRelief";
@@ -41,6 +41,12 @@ function formatWon(value: number): string {
 
 const OVERDUE_MAX_DIGITS = 3;
 
+// Figma 상세 테이블: 셀 안 입력요소는 기본 테두리 없이 배경에 묻어가고, 행 사이 구분선
+// (tr의 border-b)만 남는다. 포커스 시에만 테두리를 보여줘 편집 중임을 알린다.
+// 아래 공유 컨트롤(SelectField/TextInput/DatePicker/WonInput/PercentInput)의 기본 테두리는
+// 다른 화면(표 밖 폼)에서는 그대로 필요하므로, 테이블 셀에서만 이 클래스로 덮어쓴다.
+const CELL_INPUT_BORDERLESS = "!border-transparent focus:!border-neutral-30";
+
 function OverdueMonthsInput({
   value,
   onChange,
@@ -57,7 +63,7 @@ function OverdueMonthsInput({
         onChange(digits ? parseInt(digits, 10) : 0);
       }}
       placeholder="0"
-      className="w-full h-[34px] px-3 py-2 rounded-[5px] border border-neutral-30 bg-card text-[14px] font-medium tracking-[-0.02em] text-foreground text-right placeholder:text-neutral-50 focus:outline-none focus:border-neutral-50"
+      className={`w-full h-[34px] px-3 py-2 rounded-[5px] border border-transparent focus:border-neutral-30 bg-card text-[14px] font-medium tracking-[-0.02em] text-foreground text-right placeholder:text-neutral-50 focus:outline-none`}
     />
   );
 }
@@ -66,9 +72,10 @@ function OverdueMonthsInput({
 // 어긋날 수 있어 colgroup 하나로 세 영역 모두를 맞춘다.
 const COLUMN_WIDTHS = [
   116, // 채무종류
+  88, // 담보
   128, // 채권처
   128, // 상환방식
-  92, // 연체(개월)
+  104, // 연체(개월) — Figma 헤더 폰트(16px)로 "연체(개월)" 텍스트가 92px에서 겹쳐 여유를 둠
   156, // 대출일
   156, // 만기일
   168, // 금액(원)
@@ -81,10 +88,100 @@ const COLUMN_WIDTHS = [
 ];
 const TABLE_WIDTH = COLUMN_WIDTHS.reduce((sum, width) => sum + width, 0);
 
-const HEADER_CELL = "h-11 px-2 text-[12px] font-semibold text-neutral-60 text-left whitespace-nowrap";
-const BODY_CELL = "px-2 py-2 align-middle";
+// 헤더는 텍스트만이라 th 패딩이 그대로 시작 위치가 되지만, 바디 셀은 그 안의 input/select가
+// 자체 좌우 패딩(px-2~px-3)을 또 갖고 있어서 td 패딩과 겹쳐 헤더 라벨이 실제 값보다 왼쪽으로
+// 치우쳐 보인다. td 패딩을 줄이고 th 패딩을 늘려 그 격차를 좁힌다(완전한 픽셀 일치보단
+// "표답게 보이는" 수준으로 절충).
+const HEADER_CELL = "h-10 px-3 text-[16px] font-medium text-neutral-60 text-left whitespace-nowrap";
+const BODY_CELL = "px-1 py-2 align-middle";
 const READONLY_CELL =
-  "px-2 py-2 align-middle text-right text-[13px] font-medium text-foreground whitespace-nowrap";
+  "px-3 py-2 align-middle text-right text-[14px] font-medium text-neutral-90/80 whitespace-nowrap";
+
+function PlusIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className={className} aria-hidden>
+      <path
+        d="M8 3.33333V12.6667M3.33333 8H12.6667"
+        stroke="#B0B0B0"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function RemoveRowIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" className={className} aria-hidden>
+      <path
+        d="M5 5L15 15M5 15L15 5"
+        stroke="#B0B0B0"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+type DebtSums = {
+  principalWon: number;
+  monthlyPaymentWon: number;
+  totalInterestWon: number;
+  totalRepaymentWon: number;
+};
+
+function sumDebtItems(items: DebtItemFormState[]): DebtSums {
+  return items.reduce(
+    (acc, debt) => ({
+      principalWon: acc.principalWon + debt.principalWon,
+      monthlyPaymentWon: acc.monthlyPaymentWon + debt.monthlyPaymentWon,
+      totalInterestWon: acc.totalInterestWon + debt.totalInterestWon,
+      totalRepaymentWon: acc.totalRepaymentWon + debt.totalRepaymentWon,
+    }),
+    { principalWon: 0, monthlyPaymentWon: 0, totalInterestWon: 0, totalRepaymentWon: 0 }
+  );
+}
+
+function DebtSumCard({
+  label,
+  sums,
+  highlight = false,
+}: {
+  label: string;
+  sums: DebtSums;
+  highlight?: boolean;
+}) {
+  return (
+    <div className={`rounded-xl px-4 py-3.5 flex flex-col gap-2 ${highlight ? "bg-neutral-90" : "bg-neutral-10"}`}>
+      <div className="flex items-baseline justify-between gap-2">
+        <span className={`text-[14px] font-medium tracking-[0.2px] ${highlight ? "text-neutral-50" : "text-neutral-60"}`}>
+          {label}
+        </span>
+        <span
+          className={`text-[16px] font-bold tracking-[-0.04em] whitespace-nowrap ${
+            highlight ? "text-neutral-20" : "text-foreground"
+          }`}
+        >
+          {formatWon(sums.principalWon)}
+        </span>
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[14px] font-medium tracking-[0.2px] text-neutral-50">월불입</span>
+        <span className={`text-[14px] font-medium tracking-[0.2px] text-right whitespace-nowrap ${highlight ? "text-neutral-50" : "text-neutral-60"}`}>
+          {formatWon(sums.monthlyPaymentWon)}
+        </span>
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[14px] font-medium tracking-[0.2px] text-neutral-50">총이자</span>
+        <span className={`text-[14px] font-medium tracking-[0.2px] text-right whitespace-nowrap ${highlight ? "text-neutral-50" : "text-neutral-60"}`}>
+          {formatWon(sums.totalInterestWon)}
+        </span>
+      </div>
+    </div>
+  );
+}
 
 export default function DebtItemsTable({ debts, onChange }: Props) {
   const { containerRef, dragScrollHandlers } = useHorizontalDragScroll<HTMLDivElement>();
@@ -107,18 +204,12 @@ export default function DebtItemsTable({ debts, onChange }: Props) {
     onChange(debts.filter((debt) => debt.id !== id));
   };
 
-  const totals = debts.reduce(
-    (acc, debt) => ({
-      principalWon: acc.principalWon + debt.principalWon,
-      monthlyPaymentWon: acc.monthlyPaymentWon + debt.monthlyPaymentWon,
-      totalInterestWon: acc.totalInterestWon + debt.totalInterestWon,
-      totalRepaymentWon: acc.totalRepaymentWon + debt.totalRepaymentWon,
-    }),
-    { principalWon: 0, monthlyPaymentWon: 0, totalInterestWon: 0, totalRepaymentWon: 0 }
-  );
+  const totals = sumDebtItems(debts);
+  const collateralTotals = sumDebtItems(debts.filter((debt) => debt.isCollateralLoan));
+  const unsecuredTotals = sumDebtItems(debts.filter((debt) => !debt.isCollateralLoan));
 
   return (
-    <div className="rounded-[10px] border border-neutral-30 overflow-hidden">
+    <div className="rounded-t-[10px] border-t border-neutral-30 overflow-hidden">
       <div className="overflow-x-auto" ref={containerRef} {...dragScrollHandlers}>
         <table
           className="border-collapse table-fixed"
@@ -131,8 +222,9 @@ export default function DebtItemsTable({ debts, onChange }: Props) {
             ))}
           </colgroup>
           <thead>
-            <tr className="bg-neutral-10 border-b border-neutral-30">
+            <tr className="bg-neutral-20 border-b border-neutral-30">
               <th className={HEADER_CELL}>채무종류</th>
+              <th className={HEADER_CELL}>담보</th>
               <th className={HEADER_CELL}>채권처</th>
               <th className={HEADER_CELL}>상환방식</th>
               <th className={HEADER_CELL}>연체(개월)</th>
@@ -149,10 +241,10 @@ export default function DebtItemsTable({ debts, onChange }: Props) {
           </thead>
           <tbody>
             {debts.map((debt) => (
-              <tr key={debt.id} className="border-b border-neutral-30 last:border-b-0">
+              <tr key={debt.id} className="border-b-[0.4px] border-neutral-30 last:border-b-0">
                 <td className={BODY_CELL}>
                   <SelectField
-                    className="h-[34px] text-[13px]"
+                    className={`h-[34px] text-[13px] ${CELL_INPUT_BORDERLESS}`}
                     value={debt.debtType}
                     onChange={(e) =>
                       updateItem(debt.id, { debtType: e.target.value as DebtItemFormState["debtType"] })
@@ -166,15 +258,28 @@ export default function DebtItemsTable({ debts, onChange }: Props) {
                   </SelectField>
                 </td>
                 <td className={BODY_CELL}>
+                  <SelectField
+                    className={`h-[34px] text-[13px] ${CELL_INPUT_BORDERLESS}`}
+                    value={debt.isCollateralLoan ? "true" : "false"}
+                    onChange={(e) =>
+                      updateItem(debt.id, { isCollateralLoan: e.target.value === "true" })
+                    }
+                  >
+                    <option value="false">무담보</option>
+                    <option value="true">담보</option>
+                  </SelectField>
+                </td>
+                <td className={BODY_CELL}>
                   <TextInput
                     value={debt.creditorName}
                     onChange={(value) => updateItem(debt.id, { creditorName: value })}
                     placeholder="채권처"
+                    className={CELL_INPUT_BORDERLESS}
                   />
                 </td>
                 <td className={BODY_CELL}>
                   <SelectField
-                    className="h-[34px] text-[13px]"
+                    className={`h-[34px] text-[13px] ${CELL_INPUT_BORDERLESS}`}
                     value={debt.repaymentMethod}
                     onChange={(e) =>
                       updateItem(debt.id, {
@@ -196,29 +301,39 @@ export default function DebtItemsTable({ debts, onChange }: Props) {
                   />
                 </td>
                 <td className={BODY_CELL}>
-                  <DatePicker
-                    value={parseDateOnly(debt.loanDate)}
-                    onChange={(date) => updateItem(debt.id, { loanDate: formatDateOnly(date) })}
-                    allowTextInput
-                  />
+                  <div className="relative">
+                    <DatePicker
+                      value={parseDateOnly(debt.loanDate)}
+                      onChange={(date) => updateItem(debt.id, { loanDate: formatDateOnly(date) })}
+                      allowTextInput
+                      className={`pr-8 ${CELL_INPUT_BORDERLESS}`}
+                    />
+                    <CalendarInlineIcon className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none" />
+                  </div>
                 </td>
                 <td className={BODY_CELL}>
-                  <DatePicker
-                    value={parseDateOnly(debt.maturityDate)}
-                    onChange={(date) => updateItem(debt.id, { maturityDate: formatDateOnly(date) })}
-                    allowTextInput
-                  />
+                  <div className="relative">
+                    <DatePicker
+                      value={parseDateOnly(debt.maturityDate)}
+                      onChange={(date) => updateItem(debt.id, { maturityDate: formatDateOnly(date) })}
+                      allowTextInput
+                      className={`pr-8 ${CELL_INPUT_BORDERLESS}`}
+                    />
+                    <CalendarInlineIcon className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none" />
+                  </div>
                 </td>
                 <td className={BODY_CELL}>
                   <WonInput
                     value={debt.principalWon}
                     onChange={(value) => updateItem(debt.id, { principalWon: value })}
+                    className={CELL_INPUT_BORDERLESS}
                   />
                 </td>
                 <td className={BODY_CELL}>
                   <PercentInput
                     value={debt.interestRate}
                     onChange={(value) => updateItem(debt.id, { interestRate: value })}
+                    className={CELL_INPUT_BORDERLESS}
                   />
                 </td>
                 <td className={READONLY_CELL}>{debt.termMonths ? `${debt.termMonths}개월` : "-"}</td>
@@ -232,7 +347,7 @@ export default function DebtItemsTable({ debts, onChange }: Props) {
                     aria-label="행 삭제"
                     className="cursor-pointer inline-flex items-center justify-center w-6 h-6 hover:opacity-70"
                   >
-                    <TrashIcon />
+                    <RemoveRowIcon />
                   </button>
                 </td>
               </tr>
@@ -240,39 +355,25 @@ export default function DebtItemsTable({ debts, onChange }: Props) {
           </tbody>
           <tfoot>
             <tr className="border-t border-neutral-30">
-              <td colSpan={13} className="px-2 py-2.5">
+              <td colSpan={14} className="p-2">
                 <button
                   type="button"
                   onClick={addRow}
-                  className="cursor-pointer inline-flex items-center gap-1.5 text-[13px] font-medium text-neutral-60 hover:text-foreground"
+                  className="cursor-pointer w-full h-10 rounded-lg bg-neutral-10 inline-flex items-center gap-1.5 px-3 text-[14px] font-medium text-neutral-50 hover:text-neutral-60"
                 >
-                  <span aria-hidden>+</span>
+                  <PlusIcon />
                   행 추가
                 </button>
               </td>
             </tr>
-            <tr className="bg-neutral-10 border-t border-neutral-30">
-              <td colSpan={6} className="px-2 h-11 align-middle text-[13px] font-semibold text-foreground">
-                합계
-              </td>
-              <td className="px-2 h-11 align-middle text-right text-[14px] font-semibold text-foreground whitespace-nowrap">
-                {formatWon(totals.principalWon)}
-              </td>
-              <td />
-              <td />
-              <td className="px-2 h-11 align-middle text-right text-[14px] font-semibold text-foreground whitespace-nowrap">
-                {formatWon(totals.monthlyPaymentWon)}
-              </td>
-              <td className="px-2 h-11 align-middle text-right text-[14px] font-semibold text-foreground whitespace-nowrap">
-                {formatWon(totals.totalInterestWon)}
-              </td>
-              <td className="px-2 h-11 align-middle text-right text-[14px] font-semibold text-foreground whitespace-nowrap">
-                {formatWon(totals.totalRepaymentWon)}
-              </td>
-              <td />
-            </tr>
           </tfoot>
         </table>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 p-3 border-t border-neutral-30">
+        <DebtSumCard label="담보대출 합산" sums={collateralTotals} />
+        <DebtSumCard label="무담보대출 합산" sums={unsecuredTotals} />
+        <DebtSumCard label="총 합산" sums={totals} highlight />
       </div>
     </div>
   );

--- a/src/components/debt-relief/form/DiagnosisFormContent.tsx
+++ b/src/components/debt-relief/form/DiagnosisFormContent.tsx
@@ -29,6 +29,31 @@ import Step3Debts from "./Step3Debts";
 import Step4IncomeExpense from "./Step4IncomeExpense";
 import Step5Others from "./Step5Others";
 
+function AnalyzeSparkleIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+      <path
+        d="M9.38432 15.6434L9.37588 15.6447L9.32595 15.6672L9.31188 15.6697L9.30204 15.6672L9.2521 15.6441C9.2446 15.6423 9.23897 15.6436 9.23522 15.6479L9.23241 15.6543L9.22045 15.929L9.22397 15.9418L9.231 15.9502L9.30414 15.9977L9.31469 16.0002L9.32313 15.9977L9.39627 15.9502L9.40471 15.9399L9.40753 15.929L9.39557 15.655C9.3937 15.6481 9.38995 15.6443 9.38432 15.6434ZM9.56998 15.5709L9.56014 15.5722L9.43074 15.6319L9.4237 15.6383L9.42159 15.6453L9.43425 15.9213L9.43777 15.929L9.44339 15.9341L9.58475 15.9932C9.59366 15.9953 9.60046 15.9936 9.60515 15.9881L9.60796 15.9791L9.58405 15.585C9.58171 15.5769 9.57702 15.5722 9.56998 15.5709ZM9.06714 15.5722C9.06404 15.5705 9.06034 15.5699 9.0568 15.5706C9.05326 15.5713 9.05016 15.5733 9.04815 15.576L9.04393 15.585L9.02002 15.9791C9.02049 15.9868 9.02447 15.9919 9.03198 15.9945L9.04252 15.9932L9.18388 15.9335L9.19092 15.9284L9.19303 15.9213L9.20569 15.6453L9.20358 15.6376L9.19654 15.6312L9.06714 15.5722Z"
+        fill="url(#analyzeSparkleSmallDesktopFooter)"
+      />
+      <path
+        d="M6.93167 4.21289C7.35223 3.08976 9.05277 3.05574 9.55139 4.11085L9.59359 4.21353L10.1611 5.72816C10.2912 6.07551 10.5014 6.39338 10.7775 6.66031C11.0536 6.92724 11.3893 7.13702 11.7618 7.27551L11.9144 7.3275L13.5742 7.84478C14.8049 8.22857 14.8422 9.78042 13.6867 10.2354L13.5742 10.274L11.9144 10.7919C11.5336 10.9105 11.1852 11.1023 10.8926 11.3543C10.5999 11.6062 10.3699 11.9126 10.2181 12.2526L10.1611 12.3912L9.59429 13.9065C9.17373 15.0296 7.4732 15.0636 6.97528 14.0092L6.93167 13.9065L6.36483 12.3919C6.23485 12.0444 6.0247 11.7264 5.74857 11.4594C5.47244 11.1923 5.13675 10.9824 4.76416 10.8439L4.61225 10.7919L2.95251 10.2746C1.72106 9.8908 1.68379 8.33896 2.83998 7.88457L2.95251 7.84478L4.61225 7.3275C4.99289 7.2088 5.34121 7.01699 5.63371 6.76501C5.92622 6.51303 6.1561 6.20673 6.30786 5.86678L6.36483 5.72816L6.93167 4.21289ZM13.8892 2C14.0208 2 14.1497 2.03368 14.2614 2.09721C14.373 2.16075 14.4629 2.25158 14.5208 2.3594L14.5545 2.43449L14.8007 3.09297L15.523 3.31759C15.6548 3.35847 15.7704 3.43415 15.8551 3.53504C15.9397 3.63593 15.9897 3.75749 15.9986 3.88431C16.0075 4.01113 15.9749 4.1375 15.905 4.24741C15.8351 4.35732 15.731 4.44582 15.6059 4.5017L15.523 4.5325L14.8014 4.75713L14.5552 5.41625C14.5104 5.53654 14.4274 5.64196 14.3168 5.71917C14.2062 5.79637 14.073 5.84188 13.934 5.84992C13.795 5.85796 13.6566 5.82818 13.5362 5.76434C13.4158 5.7005 13.3189 5.60549 13.2577 5.49134L13.2239 5.41625L12.9778 4.75777L12.2555 4.53314C12.1237 4.49227 12.0081 4.41659 11.9234 4.3157C11.8387 4.21481 11.7888 4.09325 11.7799 3.96643C11.771 3.83961 11.8036 3.71324 11.8735 3.60333C11.9434 3.49342 12.0475 3.40492 12.1725 3.34904L12.2555 3.31824L12.9771 3.09361L13.2232 2.43449C13.2706 2.30769 13.3604 2.19761 13.4798 2.11969C13.5992 2.04177 13.7424 1.99992 13.8892 2Z"
+        fill="url(#analyzeSparkleMainDesktopFooter)"
+      />
+      <defs>
+        <linearGradient id="analyzeSparkleSmallDesktopFooter" x1="9.31399" y1="15.5703" x2="9.31399" y2="16.0002" gradientUnits="userSpaceOnUse">
+          <stop className="analyze-sparkle-start" stopColor="#00E272" />
+          <stop className="analyze-sparkle-end" offset="1" stopColor="#A9FFD4" />
+        </linearGradient>
+        <linearGradient id="analyzeSparkleMainDesktopFooter" x1="9" y1="2" x2="9" y2="14.7752" gradientUnits="userSpaceOnUse">
+          <stop className="analyze-sparkle-start" stopColor="#00E272" />
+          <stop className="analyze-sparkle-end" offset="1" stopColor="#A9FFD4" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}
+
 export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: string }) {
   const router = useRouter();
   const pathname = usePathname();
@@ -323,9 +348,6 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
           steps={FORM_STEPS}
           currentIndex={currentIndex}
           onSelectStep={goToStep}
-          onAnalyze={handleAnalyze}
-          analyzing={analyzing}
-          analyzeDisabled={!canAnalyze}
           isCustomerConnected={isCustomerConnected}
         />
 
@@ -405,6 +427,18 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
                 다음
               </button>
             )}
+            <button
+              type="button"
+              onClick={handleAnalyze}
+              disabled={analyzing || !canAnalyze}
+              aria-label={analyzing ? "분석 중" : "분석하기"}
+              className="analyze-button inline-flex items-center justify-center gap-2.5 w-[96px] h-[34px] px-3 text-[14px] leading-[17px] tracking-[-0.02em] font-semibold whitespace-nowrap cursor-pointer disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <span className="relative z-10 flex h-[18px] w-[18px] shrink-0 items-center justify-center">
+                <AnalyzeSparkleIcon />
+              </span>
+              <span className="relative z-10">{analyzing ? "분석 중" : "분석하기"}</span>
+            </button>
           </div>
         </section>
       </div>

--- a/src/components/debt-relief/form/FormControls.tsx
+++ b/src/components/debt-relief/form/FormControls.tsx
@@ -59,10 +59,12 @@ export function TextInput({
   value,
   onChange,
   placeholder,
+  className = "",
 }: {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
+  className?: string;
 }) {
   return (
     <input
@@ -70,7 +72,7 @@ export function TextInput({
       value={value}
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}
-      className={INPUT_CLASS}
+      className={`${INPUT_CLASS} ${className}`}
     />
   );
 }

--- a/src/components/debt-relief/form/FormSidebar.tsx
+++ b/src/components/debt-relief/form/FormSidebar.tsx
@@ -4,41 +4,12 @@ import FormCustomerSummary from "./FormCustomerSummary";
 import FormFinancialSummary from "./FormFinancialSummary";
 import FormStepChecklist from "./FormStepChecklist";
 
-function AnalyzeSparkleIcon() {
-  return (
-    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
-      <path
-        d="M9.38432 15.6434L9.37588 15.6447L9.32595 15.6672L9.31188 15.6697L9.30204 15.6672L9.2521 15.6441C9.2446 15.6423 9.23897 15.6436 9.23522 15.6479L9.23241 15.6543L9.22045 15.929L9.22397 15.9418L9.231 15.9502L9.30414 15.9977L9.31469 16.0002L9.32313 15.9977L9.39627 15.9502L9.40471 15.9399L9.40753 15.929L9.39557 15.655C9.3937 15.6481 9.38995 15.6443 9.38432 15.6434ZM9.56998 15.5709L9.56014 15.5722L9.43074 15.6319L9.4237 15.6383L9.42159 15.6453L9.43425 15.9213L9.43777 15.929L9.44339 15.9341L9.58475 15.9932C9.59366 15.9953 9.60046 15.9936 9.60515 15.9881L9.60796 15.9791L9.58405 15.585C9.58171 15.5769 9.57702 15.5722 9.56998 15.5709ZM9.06714 15.5722C9.06404 15.5705 9.06034 15.5699 9.0568 15.5706C9.05326 15.5713 9.05016 15.5733 9.04815 15.576L9.04393 15.585L9.02002 15.9791C9.02049 15.9868 9.02447 15.9919 9.03198 15.9945L9.04252 15.9932L9.18388 15.9335L9.19092 15.9284L9.19303 15.9213L9.20569 15.6453L9.20358 15.6376L9.19654 15.6312L9.06714 15.5722Z"
-        fill="url(#analyzeSparkleSmall)"
-      />
-      <path
-        d="M6.93167 4.21289C7.35223 3.08976 9.05277 3.05574 9.55139 4.11085L9.59359 4.21353L10.1611 5.72816C10.2912 6.07551 10.5014 6.39338 10.7775 6.66031C11.0536 6.92724 11.3893 7.13702 11.7618 7.27551L11.9144 7.3275L13.5742 7.84478C14.8049 8.22857 14.8422 9.78042 13.6867 10.2354L13.5742 10.274L11.9144 10.7919C11.5336 10.9105 11.1852 11.1023 10.8926 11.3543C10.5999 11.6062 10.3699 11.9126 10.2181 12.2526L10.1611 12.3912L9.59429 13.9065C9.17373 15.0296 7.4732 15.0636 6.97528 14.0092L6.93167 13.9065L6.36483 12.3919C6.23485 12.0444 6.0247 11.7264 5.74857 11.4594C5.47244 11.1923 5.13675 10.9824 4.76416 10.8439L4.61225 10.7919L2.95251 10.2746C1.72106 9.8908 1.68379 8.33896 2.83998 7.88457L2.95251 7.84478L4.61225 7.3275C4.99289 7.2088 5.34121 7.01699 5.63371 6.76501C5.92622 6.51303 6.1561 6.20673 6.30786 5.86678L6.36483 5.72816L6.93167 4.21289ZM13.8892 2C14.0208 2 14.1497 2.03368 14.2614 2.09721C14.373 2.16075 14.4629 2.25158 14.5208 2.3594L14.5545 2.43449L14.8007 3.09297L15.523 3.31759C15.6548 3.35847 15.7704 3.43415 15.8551 3.53504C15.9397 3.63593 15.9897 3.75749 15.9986 3.88431C16.0075 4.01113 15.9749 4.1375 15.905 4.24741C15.8351 4.35732 15.731 4.44582 15.6059 4.5017L15.523 4.5325L14.8014 4.75713L14.5552 5.41625C14.5104 5.53654 14.4274 5.64196 14.3168 5.71917C14.2062 5.79637 14.073 5.84188 13.934 5.84992C13.795 5.85796 13.6566 5.82818 13.5362 5.76434C13.4158 5.7005 13.3189 5.60549 13.2577 5.49134L13.2239 5.41625L12.9778 4.75777L12.2555 4.53314C12.1237 4.49227 12.0081 4.41659 11.9234 4.3157C11.8387 4.21481 11.7888 4.09325 11.7799 3.96643C11.771 3.83961 11.8036 3.71324 11.8735 3.60333C11.9434 3.49342 12.0475 3.40492 12.1725 3.34904L12.2555 3.31824L12.9771 3.09361L13.2232 2.43449C13.2706 2.30769 13.3604 2.19761 13.4798 2.11969C13.5992 2.04177 13.7424 1.99992 13.8892 2Z"
-        fill="url(#analyzeSparkleMain)"
-      />
-      <defs>
-        <linearGradient id="analyzeSparkleSmall" x1="9.31399" y1="15.5703" x2="9.31399" y2="16.0002" gradientUnits="userSpaceOnUse">
-          <stop className="analyze-sparkle-start" stopColor="#00E272" />
-          <stop className="analyze-sparkle-end" offset="1" stopColor="#A9FFD4" />
-        </linearGradient>
-        <linearGradient id="analyzeSparkleMain" x1="9" y1="2" x2="9" y2="14.7752" gradientUnits="userSpaceOnUse">
-          <stop className="analyze-sparkle-start" stopColor="#00E272" />
-          <stop className="analyze-sparkle-end" offset="1" stopColor="#A9FFD4" />
-        </linearGradient>
-      </defs>
-    </svg>
-  );
-}
-
 type Props = {
   form: DiagnosisFormState;
   derived: DiagnosisDerivedValues;
   steps: FormStepMeta[];
   currentIndex: number;
   onSelectStep: (index: number) => void;
-  onAnalyze: () => void;
-  analyzing: boolean;
-  /** 필수값 미충족(생성) / 변경 없음(수정)이면 true — 분석하기 비활성 */
-  analyzeDisabled?: boolean;
   /** 실제 고객 레코드와 연동된 데이터면 이름 옆에 연동 아이콘을 붙인다. */
   isCustomerConnected?: boolean;
 };
@@ -59,13 +30,8 @@ export default function FormSidebar({
   steps,
   currentIndex,
   onSelectStep,
-  onAnalyze,
-  analyzing,
-  analyzeDisabled = false,
   isCustomerConnected = false,
 }: Props) {
-  const disabled = analyzing || analyzeDisabled;
-
   return (
     <aside className="hidden md:flex md:w-[286px] shrink-0 flex-col surface md:rounded-[14px] pt-6 pb-8 px-[28px] shadow-[0_13px_61px_rgba(169,169,169,0.12)] dark:shadow-none">
       {/* 고객 요약 — 등록 단계에서는 고객 연결을 하지 않는 워크플로로 바뀌어 연결 버튼 제거 */}
@@ -88,23 +54,6 @@ export default function FormSidebar({
           form={form}
         />
       </div>
-
-      {/* Figma: 메뉴 → Divider 16px */}
-      <FullBleedDivider className="mt-4" />
-
-      {/* Figma: Divider → 분석하기 27px ≈ 28px, 버튼 230×44 */}
-      <button
-        type="button"
-        onClick={onAnalyze}
-        disabled={disabled}
-        aria-label={analyzing ? "분석 중" : "분석하기"}
-        className="analyze-button mt-7 w-full h-11 inline-flex items-center justify-center gap-2.5 px-3 py-1.5 text-[14px] leading-[17px] tracking-[-0.02em] font-semibold cursor-pointer disabled:cursor-not-allowed disabled:opacity-40"
-      >
-        <span className="relative z-10 flex h-[18px] w-[18px] shrink-0 items-center justify-center">
-          <AnalyzeSparkleIcon />
-        </span>
-        <span className="relative z-10">{analyzing ? "분석 중…" : "분석하기"}</span>
-      </button>
     </aside>
   );
 }

--- a/src/components/debt-relief/form/FormToggle.tsx
+++ b/src/components/debt-relief/form/FormToggle.tsx
@@ -24,18 +24,25 @@ export default function FormToggle({
   );
 }
 
-/** Figma: 카드 보더 없는 토글 행 — 모바일은 양끝 정렬, 데스크톱은 라벨↔스위치 gap 20 */
+/** Figma: 카드 보더 없는 토글 행 — 모바일은 양끝 정렬, 데스크톱은 라벨↔스위치 gap 20(기본) 또는
+ * wideGap 지정 시 150(새출발기금 결격·이력 확인처럼 여백을 넓게 둬야 하는 곳) */
 export function FormToggleRow({
   label,
   checked,
   onChange,
+  wideGap = false,
 }: {
   label: string;
   checked: boolean;
   onChange: (checked: boolean) => void;
+  wideGap?: boolean;
 }) {
   return (
-    <div className="flex items-center justify-between gap-5 min-h-[34px] w-full md:justify-start">
+    <div
+      className={`flex items-center justify-between gap-5 min-h-[34px] w-full md:justify-start ${
+        wideGap ? "md:gap-[150px]" : ""
+      }`}
+    >
       <span className="min-w-0 text-[14px] font-medium leading-[17px] text-foreground">{label}</span>
       <FormToggle checked={checked} onChange={onChange} ariaLabel={label} />
     </div>

--- a/src/components/debt-relief/form/PillSelect.tsx
+++ b/src/components/debt-relief/form/PillSelect.tsx
@@ -3,7 +3,9 @@ import type { PillOption } from "@/types/debtRelief";
 // Figma Ticker3
 // 모바일: h-31, px-12 py-7, gap 8 / 데스크톱: h-34, px-20 py-4, radius 30
 // 선택 = #000 흰 글자 / 미선택 = border #E2E2E2, 글자 opacity 0.8
-function PillButton({
+// PillSelect/PillMultiSelect 외에도 필드에 안 묶인 단발성 예/아니오 토글(로컬 UI 상태 등)에서
+// 재사용할 수 있게 export한다.
+export function PillButton({
   label,
   selected,
   onClick,

--- a/src/components/debt-relief/form/Step3Debts.tsx
+++ b/src/components/debt-relief/form/Step3Debts.tsx
@@ -75,6 +75,7 @@ export default function Step3Debts({ form, update, derived, debtSumOverLimitChec
         <FormField
           label="채무발생 원인"
           hint="(중복선택 가능)"
+          required
           filled={form.debtCauses.length > 0}
         >
           <PillMultiSelect

--- a/src/components/debt-relief/form/Step5Others.tsx
+++ b/src/components/debt-relief/form/Step5Others.tsx
@@ -1,11 +1,16 @@
+import { useEffect, useState } from "react";
+import { showConfirmModal } from "@/providers/ConfirmModalProvider";
+import type { AnalysisFreshStartFundInsolvencyReason } from "@/types/analysis";
 import {
+  BUSINESS_OPERATION_STATUS_OPTIONS,
+  FRESH_START_FUND_INSOLVENCY_REASON_OPTIONS,
   SPECIAL_ELIGIBILITY_OPTIONS,
   type DiagnosisFormState,
   type SpecialEligibilityType,
 } from "@/types/debtRelief";
 import { FormField, FormSectionTitle } from "./FormControls";
 import { FormToggleRow } from "./FormToggle";
-import { PillMultiSelect } from "./PillSelect";
+import { PillButton, PillMultiSelect, PillSelect } from "./PillSelect";
 
 // 만 29세 이하/만 65세 이상은 동시 선택 불가 — 서로의 상대값
 const AGE_EXCLUSIVE_PAIR: Partial<Record<SpecialEligibilityType, SpecialEligibilityType>> = {
@@ -26,15 +31,85 @@ const DETAIL_INPUT_CLASS =
 const TEXTAREA_CLASS =
   "w-full h-[84px] px-3 py-2 rounded-[5px] border border-neutral-30 bg-card text-[14px] font-medium tracking-[-0.02em] text-foreground placeholder:text-neutral-60 focus:outline-none focus:border-neutral-50 resize-none";
 
+// FormSectionTitle(FormControls.tsx)은 "데스크톱만, 모바일은 상단 드로어 스텝명이 대신함"
+// 전제로 hidden md:block이다 — 이 스텝에 섹션이 "소송 및 채무조정 이력" 하나뿐일 때는 맞는
+// 전제였지만, 새출발기금 섹션이 추가되며 모바일에서 두 섹션의 경계가 안 보이게 됐다(바로
+// 다음 항목인 "이전 신청 이력 있음"↔"이전 개인회생/파산 신청 이력 있음"이 라벨까지 비슷해
+// 헷갈리기 쉬움). FormSectionTitle 자체(다른 스텝도 공유)는 그대로 두고, 이 스텝에서만
+// 모바일 전용 제목을 나란히 둔다.
+function MobileSectionTitle({ children }: { children: string }) {
+  return (
+    <h3 className="md:hidden text-[16px] font-semibold tracking-[0.2px] text-foreground pb-3 border-b border-neutral-30">
+      {children}
+    </h3>
+  );
+}
+
 /**
  * 기타사항 스텝 — Figma: 토글 행(라벨+스위치) + on 시 상세 인풋, 특이사항 textarea.
  * 카드 보더 없음. 항목 간 gap 24px.
  */
 export default function Step5Others({ form, update, onClose }: Props) {
+  // "'20.4~'25.6 기간 중 영위했는지"는 API에 대응 필드가 없는 로컬 전용 상태다 — 1단계
+  // isOperatingBusiness(사업 영위 이력 전체)와 새출발기금 특례 기간이 항상 일치하진 않아서
+  // (예: 2015~2018년에만 사업했다 접은 경우 1단계는 "예"지만 이 기간엔 "아니오"), 상담사가
+  // "사업영위 해당 시 추가 확인" 박스를 볼지 말지만 이걸로 로컬 판단한다. isOperatingBusiness가
+  // true가 될 때마다 "예"로 리셋되고, 저장되지 않으므로 페이지를 새로고침하면 다시 "예"로
+  // 돌아온다 — 실제 제출 데이터(현재 사업 상태 등)는 이 값과 무관하게 그대로 유지된다.
+  const [appliesToFreshStartFundPeriod, setAppliesToFreshStartFundPeriod] = useState(true);
+  useEffect(() => {
+    if (form.isOperatingBusiness) setAppliesToFreshStartFundPeriod(true);
+  }, [form.isOperatingBusiness]);
+
+  // "예"/"아니오" 버튼은 항상 둘 다 보인다. 1단계가 "아니오"인 상태에서 "예"를 누르면 —
+  // 이 질문이 사실상 1단계 "사업 영위 이력"의 특례기간 한정 버전이라 — 1단계 값도 함께
+  // 켜야 앞뒤가 맞는다는 걸 상담사가 놓치기 쉬워, 확인 모달로 명시하고 동의 시에만 두 값을
+  // 같이 켠다. 1단계가 이미 "예"면 이 로컬 플래그만 토글하면 되니 모달 없이 바로 처리한다.
+  const freshStartFundPeriodSelectedAsYes = form.isOperatingBusiness && appliesToFreshStartFundPeriod;
+
+  const handleFreshStartFundPeriodYes = () => {
+    if (form.isOperatingBusiness) {
+      setAppliesToFreshStartFundPeriod(true);
+      return;
+    }
+    showConfirmModal({
+      headline: "사업 영위 이력을 함께 켤까요?",
+      message:
+        "1단계(기본정보)의 \"사업 영위 이력\"이 꺼져 있어요. 새출발기금 특례기간 질문에 \"예\"로 답하면 1단계 값도 함께 \"예\"로 바뀝니다.",
+      confirmText: "예로 변경",
+      onConfirm: () => {
+        update("isOperatingBusiness", true);
+        setAppliesToFreshStartFundPeriod(true);
+      },
+    });
+  };
+
+  const handleFreshStartFundPeriodNo = () => {
+    if (form.isOperatingBusiness) setAppliesToFreshStartFundPeriod(false);
+    // 1단계가 이미 "아니오"면 이 질문도 사실상 "아니오"라 더 할 일이 없다.
+  };
+
   const handleSpecialEligibilityChange = (next: SpecialEligibilityType[]) => {
     const added = next.find((item) => !form.specialEligibility.includes(item));
     const conflicting = added ? AGE_EXCLUSIVE_PAIR[added] : undefined;
     update("specialEligibility", conflicting ? next.filter((item) => item !== conflicting) : next);
+  };
+
+  // "해당없음"은 다른 부실사유와 동시 선택 불가 — 어느 한쪽을 새로 고르면 반대쪽을 모두 걷어낸다.
+  const handleInsolvencyReasonsChange = (next: AnalysisFreshStartFundInsolvencyReason[]) => {
+    const added = next.find((item) => !form.freshStartFundInsolvencyReasons.includes(item));
+    if (added === "not_applicable") {
+      update("freshStartFundInsolvencyReasons", ["not_applicable"]);
+      return;
+    }
+    if (added) {
+      update(
+        "freshStartFundInsolvencyReasons",
+        next.filter((item) => item !== "not_applicable")
+      );
+      return;
+    }
+    update("freshStartFundInsolvencyReasons", next);
   };
 
   return (
@@ -42,10 +117,11 @@ export default function Step5Others({ form, update, onClose }: Props) {
       {/* 모바일 전용 — 이 스텝은 다른 스텝과 달리 본문이 토글 목록으로 바로 시작해서, 카드
           우상단에 절대배치된 닫기(X)만 있으면 첫 항목 옆에 어색하게 떠 보인다. 타이틀 행을
           만들어 그 오른쪽 끝에 X를 두고, 카드 우상단의 절대배치 X는 이 스텝에서만 숨긴다
-          (DiagnosisFormContent.tsx 참고). */}
+          (DiagnosisFormContent.tsx 참고). 새출발기금 섹션이 추가되며 이 스텝이 더 이상 "소송
+          이력" 하나만 다루지 않아 스텝 이름(steps.ts의 "기타사항")으로 바꿨다. */}
       <div className="md:hidden flex items-center justify-between pb-3 border-b border-neutral-30">
         <h3 className="text-[16px] font-semibold tracking-[0.2px] text-foreground">
-          소송 및 채무조정 이력
+          기타사항
         </h3>
         <button
           type="button"
@@ -64,7 +140,86 @@ export default function Step5Others({ form, update, onClose }: Props) {
           </svg>
         </button>
       </div>
-      <FormSectionTitle>소송 및 채무조정 이력</FormSectionTitle>
+
+      <MobileSectionTitle>새출발기금</MobileSectionTitle>
+      <FormSectionTitle>새출발기금</FormSectionTitle>
+      <div className="mt-3 md:mt-6 flex flex-col gap-5">
+        <div className="flex flex-col gap-3">
+          <p className="text-[14px] font-medium leading-[17px] text-neutral-60">
+            &apos;20.4월 ~ &apos;25.6월 중 개인사업자·소상공인으로 사업 영위한 적 있음
+            (현재 고용 형태와 무관·휴업·폐업 포함)
+          </p>
+          {/* 예/아니오 버튼은 1단계 값과 무관하게 항상 둘 다 눌린다. 1단계가 "아니오"인 상태에서
+              "예"를 누르면 확인 모달을 거쳐 1단계 값도 함께 켠다(handleFreshStartFundPeriodYes) —
+              그래서 이 로컬 상태가 1단계보다 앞서 "예"가 되는 경우가 없다. */}
+          <div className="flex gap-2">
+            <PillButton
+              label="예"
+              selected={freshStartFundPeriodSelectedAsYes}
+              onClick={handleFreshStartFundPeriodYes}
+            />
+            <PillButton
+              label="아니오"
+              selected={!freshStartFundPeriodSelectedAsYes}
+              onClick={handleFreshStartFundPeriodNo}
+            />
+          </div>
+        </div>
+
+        {freshStartFundPeriodSelectedAsYes && (
+          <div className="rounded-[14px] border border-neutral-30 overflow-hidden">
+            {/* Figma: 헤더 스트립(위쪽만 라운드)만 회색, divider 아래 본문은 흰 배경 —
+                DebtHistoryCard.tsx와 동일한 헤더/바디 분리 패턴 */}
+            <div className="bg-neutral-10 px-5 py-3.5 border-b border-neutral-30">
+              <h4 className="text-[14px] font-semibold text-neutral-70">사업영위 해당 시 추가 확인</h4>
+            </div>
+            <div className="bg-card px-5 py-5 flex flex-col gap-5">
+              <FormField label="현재 사업 상태" filled={form.businessOperationStatus !== null}>
+                <PillSelect
+                  options={BUSINESS_OPERATION_STATUS_OPTIONS}
+                  value={form.businessOperationStatus}
+                  onChange={(value) => update("businessOperationStatus", value)}
+                />
+              </FormField>
+
+              <FormField
+                label="부실·부실우려 해당 여부"
+                hint="(중복선택 가능)"
+                filled={form.freshStartFundInsolvencyReasons.length > 0}
+              >
+                <PillMultiSelect
+                  options={FRESH_START_FUND_INSOLVENCY_REASON_OPTIONS}
+                  value={form.freshStartFundInsolvencyReasons}
+                  onChange={handleInsolvencyReasonsChange}
+                />
+              </FormField>
+
+              <div className="flex flex-col gap-3">
+                <span className="text-[14px] font-medium leading-[17px] text-foreground">
+                  결격·이력 확인
+                </span>
+                <FormToggleRow
+                  label="제외 업종 해당 (부동산 임대업, 법무·회계·세무 등)"
+                  checked={form.isExcludedIndustryForFreshStartFund}
+                  onChange={(checked) => update("isExcludedIndustryForFreshStartFund", checked)}
+                  wideGap
+                />
+                <FormToggleRow
+                  label="이전 신청 이력 있음 (원칙적으로 1회만 신청 가능)"
+                  checked={form.hasPreviousFreshStartFundApplication}
+                  onChange={(checked) => update("hasPreviousFreshStartFundApplication", checked)}
+                  wideGap
+                />
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-6">
+        <MobileSectionTitle>소송 및 채무조정 이력</MobileSectionTitle>
+        <FormSectionTitle>소송 및 채무조정 이력</FormSectionTitle>
+      </div>
 
       <div className="mt-3 md:mt-6 flex flex-col gap-6">
         <ToggleDetailRow

--- a/src/components/debt-relief/form/steps.ts
+++ b/src/components/debt-relief/form/steps.ts
@@ -13,5 +13,5 @@ export const FORM_STEPS: FormStepMeta[] = [
   { key: "assets", label: "자산 현황", title: "자산 현황", description: "보유 자산의 종류와 규모를 파악합니다." },
   { key: "debts", label: "채무 현황", title: "채무 현황", description: "채무 규모와 연체 현황을 확인합니다." },
   { key: "income", label: "소득 / 지출", title: "소득 / 지출", description: "월 소득과 고정 지출을 계산합니다." },
-  { key: "others", label: "기타사항", title: "기타사항", description: "신청 이력, 소송 여부 등을 확인합니다." },
+  { key: "others", label: "기타사항", title: "기타사항", description: "새출발기금 자격, 신청 이력, 소송 여부를 확인합니다." },
 ];

--- a/src/components/debt-relief/form/validateDiagnosisForm.ts
+++ b/src/components/debt-relief/form/validateDiagnosisForm.ts
@@ -4,7 +4,9 @@ import type { FormStepKey } from "./steps";
 // 채무현황 스텝의 필수값은 입력 모드에 따라 달라진다.
 // - 간편(simple): 채무종류 선택 + 연체기간 직접 입력
 // - 상세(detailed): 채무 항목 1건 이상. 연체기간은 서버가 항목별 최대값으로 자동 계산하므로 받지 않는다.
-function getMissingDebtFieldLabels(form: DiagnosisFormState): string[] {
+// 결과화면 「채무 상세」모달(DebtHistoryCard만 재사용, 채무발생 원인 UI가 없음)도 이 함수를
+// 그대로 써서 자기 화면에 없는 필드를 요구하지 않도록 한다 — 채무발생 원인은 별도로 검사한다.
+export function getMissingDebtFieldLabels(form: DiagnosisFormState): string[] {
   const missing: string[] = [];
   if (form.debtInputMode === "detailed") {
     if (form.debts.length === 0) missing.push("채무 항목");
@@ -31,6 +33,7 @@ export function getMissingRequiredFieldLabels(form: DiagnosisFormState): string[
   if (!form.monthlyIncome) missing.push("월 소득 구간");
   if (!form.housingType) missing.push("주거 형태");
   missing.push(...getMissingDebtFieldLabels(form));
+  if (form.debtCauses.length === 0) missing.push("채무발생 원인");
   if (!form.financialAsset) missing.push("금융 자산");
   if (!form.vehicle) missing.push("차량 보유");
   return missing;
@@ -58,8 +61,11 @@ export function getMissingRequiredFieldLabelsForStep(
       if (!form.vehicle) missing.push("차량 보유");
       return missing;
     }
-    case "debts":
-      return getMissingDebtFieldLabels(form);
+    case "debts": {
+      const missing = getMissingDebtFieldLabels(form);
+      if (form.debtCauses.length === 0) missing.push("채무발생 원인");
+      return missing;
+    }
     case "income": {
       const missing: string[] = [];
       if (!form.employmentType) missing.push("고용 형태");

--- a/src/components/debt-relief/result/DebtDetailModal.tsx
+++ b/src/components/debt-relief/result/DebtDetailModal.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import BaseModal from "@/components/common/BaseModal";
 import DebtHistoryCard from "@/components/debt-relief/form/DebtHistoryCard";
-import { getMissingRequiredFieldLabelsForStep } from "@/components/debt-relief/form/validateDiagnosisForm";
+import { getMissingDebtFieldLabels } from "@/components/debt-relief/form/validateDiagnosisForm";
 import { showErrorModal } from "@/providers/ErrorFeedbackModalProvider";
 import {
   DebtReliefService,
@@ -105,7 +105,7 @@ export default function DebtDetailModal({
   const handleApplyClick = () => {
     if (!canEdit || submitting) return;
 
-    const missing = getMissingRequiredFieldLabelsForStep(form, "debts");
+    const missing = getMissingDebtFieldLabels(form);
     if (missing.length > 0) {
       showErrorModal({
         headline: "필수 항목을 확인해 주세요.",

--- a/src/components/debt-relief/result/ProcedureGuideModal.tsx
+++ b/src/components/debt-relief/result/ProcedureGuideModal.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import BaseModal from "@/components/common/BaseModal";
+import { RECOMMENDED_PROCEDURE_LABEL, type RecommendedProcedure } from "@/types/debtRelief";
+
+type ProcedureGuideContent = {
+  procedure: RecommendedProcedure;
+  summary: string;
+  eligibility: string[];
+  coreRules: string[];
+  reliefStructure: string;
+  duration: string;
+  caution: string;
+};
+
+// 6개 절차 제도 안내 원문 — 상담사가 고객에게 절차 개요를 설명할 때 참고하는 고정 문구.
+const PROCEDURE_GUIDE_CONTENTS: ProcedureGuideContent[] = [
+  {
+    procedure: "individual_rehabilitation",
+    summary: "법원을 통해 채무를 조정하고 가용소득으로 분할 변제하는 제도",
+    eligibility: [
+      "무담보 10억 이하 / 담보 15억 이하",
+      "장래 계속적·반복적 수입 가능",
+      "채무초과 상태 (채무 > 재산)",
+    ],
+    coreRules: [
+      "변제계획안 제출 및 법원 인가 필요",
+      "인가 후 채권자 추심·강제집행 제한",
+      "이전 면책 후 일정 기간 재신청 제한",
+    ],
+    reliefStructure: "가용소득 기준 월 변제 · 변제 완료 후 잔여 채무 면책",
+    duration: "통상 3~5년 (최장 5년, 실무상 최대 7년 사례 있음)",
+    caution: "소득·재산 허위 신고 시 면책 취소·형사 리스크",
+  },
+  {
+    procedure: "speedy_debt_adjustment",
+    summary: "연체 초기 채무의 이자·기간을 조정하는 신용회복위원회 제도",
+    eligibility: [
+      "연체 30일 이하 (단기 연체)",
+      "총 채무 일정 한도 이내 (무담보·담보 기준)",
+      "협약 금융회사 채무 중심",
+    ],
+    coreRules: [
+      "원금 감면 없음이 원칙",
+      "이자율 인하·분할상환 중심",
+      "채권기관 동의 절차 필요",
+    ],
+    reliefStructure: "연체이자·약정이자 조정 · 원금은 원칙적으로 전액 상환",
+    duration: "최장 10년 분할상환",
+    caution: "장기 연체·고액 감면이 목표면 개인워크아웃·회생과 비교 필요",
+  },
+  {
+    procedure: "pre_workout",
+    summary: "연체 31~89일 구간의 이자·기간 조정을 위한 신용회복 제도",
+    eligibility: [
+      "연체 31일 이상 89일 미만",
+      "총 채무 15억 이하 (무담보 5억·담보 10억)",
+      "협약 가입 금융기관 채무",
+    ],
+    coreRules: [
+      "원금 감면은 원칙적으로 없음",
+      "연체이자 감면·이자율 조정이 중심",
+      "채권기관 동의율 충족 필요",
+    ],
+    reliefStructure: "연체이자 감면 · 이자율 조정 · 분할상환",
+    duration: "최장 10년 분할상환",
+    caution: "연체 기간이 길어지면 개인워크아웃 전환을 검토",
+  },
+  {
+    procedure: "personal_workout",
+    summary: "연체 90일 이상 채무의 이자·원금 일부를 조정하는 신용회복 제도",
+    eligibility: [
+      "연체 90일 이상",
+      "총 채무 15억 이하",
+      "최저생계비 이상 수입 또는 상환 가능성",
+    ],
+    coreRules: [
+      "이자 전액 감면·원금 일부 감면 검토 가능",
+      "사채·비협약 채무는 대상 제외될 수 있음",
+      "성실 납부 시 신용 회복에 유리",
+    ],
+    reliefStructure: "이자 감면 + 원금 일부 감면 후 분할상환",
+    duration: "최장 8~10년 분할상환 (조건에 따라 상이)",
+    caution: "감면 폭·대상 채무 범위는 사전 확인 필수",
+  },
+  {
+    procedure: "fresh_start_fund",
+    summary: "코로나 시기 개인사업자·소상공인 대상 채무조정 제도",
+    eligibility: [
+      "'20.4~'25.6 중 개인사업자·소상공인 사업 영위",
+      "부실·부실우려 요건 해당",
+      "제외 업종·기신청 이력 없을 것",
+    ],
+    coreRules: [
+      "원칙적으로 1회만 신청 가능",
+      "협약 금융회사 사업·가계대출 중심",
+      "사업 상태(영업·휴업·폐업)에 따라 조건 상이",
+    ],
+    reliefStructure: "원금·이자 조정 후 장기 분할상환 (소득·재산에 따라 감면율 변동)",
+    duration: "최장 10년 분할상환",
+    caution: "제외 업종·법인 폐업·기신청 여부를 반드시 확인",
+  },
+  {
+    procedure: "bankruptcy",
+    summary: "지급불능 상태에서 채무를 정리하고 면책을 받는 법원 절차",
+    eligibility: [
+      "지급불능 상태 (소득·재산으로 변제 곤란)",
+      "채무초과",
+      "면책 불허가 사유 해당 여부 검토",
+    ],
+    coreRules: [
+      "월 변제계획보다 면책·자산 환가가 핵심",
+      "일부 직종 취업 제한 가능",
+      "세금·양육비 등 면책 제외 채무 존재",
+    ],
+    reliefStructure: "면책결정 시 잔여 채무 소멸 (제외채무 제외)",
+    duration: "통상 수개월~1년 내외 (사안별 상이)",
+    caution: "가용소득이 있으면 파산보다 개인회생이 권고되는 경우가 많음",
+  },
+];
+
+function CloseIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden>
+      <path
+        d="M6 18L18 6M6 6L18 18"
+        stroke="#B0B0B0"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function ChevronIcon({ direction }: { direction: "left" | "right" }) {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 20 20"
+      fill="none"
+      aria-hidden
+      className={direction === "left" ? "rotate-90" : "-rotate-90"}
+    >
+      <path
+        d="M15.8332 7.5L9.99984 13.3333L4.1665 7.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function WarningIcon() {
+  return (
+    <svg className="shrink-0 mt-0.5" width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+      <path d="M7 1.5L13 12H1L7 1.5Z" fill="#EFB008" />
+      <path d="M7 5.5v3" stroke="white" strokeWidth="1.4" strokeLinecap="round" />
+      <circle cx="7" cy="10.2" r="0.7" fill="white" />
+    </svg>
+  );
+}
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  // 열릴 때 어느 절차 페이지부터 보여줄지 — 결과 화면에서 현재 선택된 절차로 맞춰 연다.
+  initialProcedure?: RecommendedProcedure;
+};
+
+export default function ProcedureGuideModal({ open, onClose, initialProcedure }: Props) {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (!open) return;
+    const foundIndex = PROCEDURE_GUIDE_CONTENTS.findIndex(
+      (content) => content.procedure === initialProcedure
+    );
+    setIndex(foundIndex >= 0 ? foundIndex : 0);
+  }, [open, initialProcedure]);
+
+  if (!open) return null;
+
+  const total = PROCEDURE_GUIDE_CONTENTS.length;
+  const content = PROCEDURE_GUIDE_CONTENTS[index];
+  const canGoPrev = index > 0;
+  const canGoNext = index < total - 1;
+
+  return (
+    <BaseModal
+      onClose={onClose}
+      overlayClassName="bg-black/50 dark:bg-[#000000CC]"
+      disableAutoContainerSizing
+      containerClassName="relative w-[92vw] max-w-[520px] md:w-[520px] max-h-[90vh] rounded-[14px] bg-white dark:bg-neutral-10 shadow-[0px_13px_61px_rgba(169,169,169,0.366)] dark:shadow-none flex flex-col overflow-hidden"
+      ariaLabel="제도 안내"
+    >
+      <div className="flex items-center justify-between px-6 md:px-7 pt-6 pb-4 shrink-0">
+        <h2 className="text-[18px] font-semibold text-ink dark:text-neutral-90">제도 안내</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="닫기"
+          className="cursor-pointer grid h-6 w-6 place-items-center"
+        >
+          <CloseIcon />
+        </button>
+      </div>
+      <div className="border-t border-neutral-30 dark:border-[#4D4D4D] shrink-0" />
+
+      <div className="min-w-0 flex-1 overflow-y-auto px-6 md:px-7 py-5 flex flex-col gap-4">
+        <div className="flex items-baseline justify-between gap-2">
+          <h3 className="text-[20px] font-bold leading-6 tracking-[-0.02em] text-foreground">
+            {RECOMMENDED_PROCEDURE_LABEL[content.procedure]}
+          </h3>
+          <span className="shrink-0 text-[13px] font-medium leading-4 text-neutral-60">
+            {index + 1}/{total}
+          </span>
+        </div>
+        <p className="text-[14px] font-medium leading-5 tracking-[-0.02em] text-neutral-60">
+          {content.summary}
+        </p>
+
+        <div>
+          <p className="text-[13px] font-semibold leading-4 tracking-[-0.02em] text-foreground mb-1.5">
+            대상 / 자격
+          </p>
+          <ul className="flex flex-col gap-1">
+            {content.eligibility.map((item, itemIndex) => (
+              <li
+                key={itemIndex}
+                className="text-[13px] font-medium leading-5 tracking-[-0.02em] text-neutral-60"
+              >
+                · {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div>
+          <p className="text-[13px] font-semibold leading-4 tracking-[-0.02em] text-foreground mb-1.5">
+            핵심 규칙
+          </p>
+          <ul className="flex flex-col gap-1">
+            {content.coreRules.map((item, itemIndex) => (
+              <li
+                key={itemIndex}
+                className="text-[13px] font-medium leading-5 tracking-[-0.02em] text-neutral-60"
+              >
+                · {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div>
+          <p className="text-[13px] font-semibold leading-4 tracking-[-0.02em] text-foreground mb-1.5">
+            감면·변제 구조
+          </p>
+          <p className="text-[13px] font-medium leading-5 tracking-[-0.02em] text-neutral-60">
+            {content.reliefStructure}
+          </p>
+        </div>
+
+        <div>
+          <p className="text-[13px] font-semibold leading-4 tracking-[-0.02em] text-foreground mb-1.5">
+            기간
+          </p>
+          <p className="text-[13px] font-medium leading-5 tracking-[-0.02em] text-neutral-60">
+            {content.duration}
+          </p>
+        </div>
+
+        <div className="inline-flex items-start gap-1.5 max-w-full min-h-7 px-3 py-1.5 rounded-[5px] bg-warning-10 dark:bg-[rgb(var(--color-amber-600-rgb)/0.3)]">
+          <WarningIcon />
+          <span className="text-[13px] font-medium leading-5 tracking-[-0.02em] opacity-80 text-warning-100 dark:text-warning-40">
+            {content.caution}
+          </span>
+        </div>
+      </div>
+
+      <div className="border-t border-neutral-30 dark:border-[#4D4D4D] shrink-0" />
+      <div className="flex items-center justify-between px-6 md:px-7 py-3.5 shrink-0">
+        <button
+          type="button"
+          onClick={() => setIndex((prev) => Math.max(0, prev - 1))}
+          disabled={!canGoPrev}
+          className={`inline-flex items-center gap-1 h-[34px] px-3 rounded-[5px] border border-neutral-30 dark:border-[#4D4D4D] bg-white dark:bg-neutral-10 text-[14px] font-semibold leading-[17px] tracking-[-0.02em] text-ink dark:text-neutral-90 ${
+            canGoPrev ? "cursor-pointer hover:bg-neutral-10 dark:hover:bg-neutral-20" : "opacity-40 cursor-not-allowed"
+          }`}
+        >
+          <ChevronIcon direction="left" />
+          이전
+        </button>
+
+        <div className="flex items-center gap-1.5">
+          {PROCEDURE_GUIDE_CONTENTS.map((item, itemIndex) => (
+            <button
+              key={item.procedure}
+              type="button"
+              onClick={() => setIndex(itemIndex)}
+              aria-label={`${RECOMMENDED_PROCEDURE_LABEL[item.procedure]} 안내로 이동`}
+              aria-current={itemIndex === index}
+              className={`h-2 rounded-full transition-all cursor-pointer ${
+                itemIndex === index ? "w-5 bg-neutral-90 dark:bg-neutral-90" : "w-2 bg-neutral-30"
+              }`}
+            />
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setIndex((prev) => Math.min(total - 1, prev + 1))}
+          disabled={!canGoNext}
+          className={`inline-flex items-center gap-1 h-[34px] px-3 rounded-[5px] border border-neutral-30 dark:border-[#4D4D4D] bg-white dark:bg-neutral-10 text-[14px] font-semibold leading-[17px] tracking-[-0.02em] text-ink dark:text-neutral-90 ${
+            canGoNext ? "cursor-pointer hover:bg-neutral-10 dark:hover:bg-neutral-20" : "opacity-40 cursor-not-allowed"
+          }`}
+        >
+          다음
+          <ChevronIcon direction="right" />
+        </button>
+      </div>
+    </BaseModal>
+  );
+}

--- a/src/components/debt-relief/result/SectionDebtAdjustmentComparison.tsx
+++ b/src/components/debt-relief/result/SectionDebtAdjustmentComparison.tsx
@@ -25,7 +25,7 @@ export default function SectionDebtAdjustmentComparison({ detail }: { detail: Di
     <div className="flex flex-col gap-3">
       <div>
         <h2 className="inline-flex h-6 items-center text-[16px] font-semibold leading-none tracking-[0.2px] text-foreground">
-          채무조정 비교
+          개인회생과 개인워크아웃 비교
         </h2>
         <div className="mt-3 border-t border-neutral-30" />
       </div>

--- a/src/components/debt-relief/result/SectionDebtStatus.tsx
+++ b/src/components/debt-relief/result/SectionDebtStatus.tsx
@@ -45,9 +45,18 @@ export default function SectionDebtStatus({
   return (
     <div className="flex flex-col gap-5">
       <div>
-        <h2 className="text-[16px] font-semibold leading-[19px] tracking-[0.2px] text-foreground">
-          채무 현황
-        </h2>
+        <div className="flex items-center gap-3">
+          <h2 className="text-[16px] font-semibold leading-[19px] tracking-[0.2px] text-foreground">
+            채무 현황
+          </h2>
+          <button
+            type="button"
+            onClick={() => setDebtDetailOpen(true)}
+            className="cursor-pointer inline-flex items-center justify-center h-7 px-2.5 rounded-[5px] border border-neutral-30 bg-neutral-0 text-[13px] font-medium leading-4 tracking-[-0.02em] text-neutral-60 hover:bg-neutral-10 whitespace-nowrap"
+          >
+            자세히 보기
+          </button>
+        </div>
         <div className="mt-3 border-t border-neutral-30" />
       </div>
 
@@ -89,16 +98,7 @@ export default function SectionDebtStatus({
 
         {/* 우: 채무 구성 */}
         <div className="min-w-0">
-          <div className="flex items-center justify-between gap-3 mb-[12px]">
-            <p className="text-[14px] font-medium leading-[17px] text-neutral-60">채무 구성</p>
-            <button
-              type="button"
-              onClick={() => setDebtDetailOpen(true)}
-              className="cursor-pointer inline-flex items-center justify-center h-7 px-2.5 rounded-[5px] border border-neutral-30 bg-neutral-0 text-[13px] font-medium leading-4 tracking-[-0.02em] text-neutral-60 hover:bg-neutral-10 whitespace-nowrap"
-            >
-              자세히 보기
-            </button>
-          </div>
+          <p className="text-[14px] font-medium leading-[17px] text-neutral-60 mb-[12px]">채무 구성</p>
           <div className="flex flex-col gap-[13px]">
             {debt.composition.map((item) => (
               <div key={item.label} className="flex items-center gap-3">

--- a/src/components/debt-relief/result/SectionProcedureScores.tsx
+++ b/src/components/debt-relief/result/SectionProcedureScores.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/types/debtRelief";
 import { scoreToGrade } from "@/services/debtRelief";
 import DisclaimerInfoTooltip from "./DisclaimerInfoTooltip";
+import ProcedureGuideModal from "./ProcedureGuideModal";
 
 // 신용회복 3종(신속채무조정/프리워크아웃/개인워크아웃)은 API에 자체 대표 점수가 없어,
 // 결과 화면에서만 "신용회복" 카드 + 플로팅 드롭다운으로 묶어 보여준다. 화면 전용 그룹핑이라
@@ -390,6 +391,7 @@ export default function SectionProcedureScores({
   // 하위 절차는 플로팅 드롭다운으로만 보여서 그리드 높이를 밀지 않는다.
   // 기본은 닫힘 — 헤더 선택 스타일로 신용회복 그룹 선택 여부를 표시한다.
   const [creditRecoveryOpen, setCreditRecoveryOpen] = useState(false);
+  const [guideOpen, setGuideOpen] = useState(false);
 
   const selectedScore = detail.procedureScores.find(
     (score) => score.procedure === selectedProcedure
@@ -447,9 +449,18 @@ export default function SectionProcedureScores({
       {/* 조건 분석 카드 */}
       <div className="min-w-0 rounded-[12px] border border-neutral-30 overflow-hidden">
         <div className="min-h-[42px] px-4 md:px-5 py-2 md:py-0 bg-neutral-10 flex flex-wrap items-center justify-between gap-2 md:gap-3">
-          <h3 className="text-[14px] font-semibold leading-[17px] tracking-[-0.02em] text-foreground">
-            {selectedScore?.label ?? detail.recommendation.title} 조건 분석
-          </h3>
+          <div className="flex items-center gap-2 min-w-0">
+            <h3 className="text-[14px] font-semibold leading-[17px] tracking-[-0.02em] text-foreground truncate">
+              {selectedScore?.label ?? detail.recommendation.title} 조건 분석
+            </h3>
+            <button
+              type="button"
+              onClick={() => setGuideOpen(true)}
+              className="cursor-pointer inline-flex items-center justify-center h-[24px] px-2.5 rounded-full border border-neutral-30 bg-neutral-0 text-[12px] font-medium leading-[14px] text-neutral-60 hover:bg-neutral-10 shrink-0"
+            >
+              제도 안내
+            </button>
+          </div>
           <div className="flex items-center gap-1.5 md:gap-2 shrink-0">
             {(["met", "caution", "risk"] as ConditionStatus[]).map((status) => (
               <span
@@ -485,6 +496,12 @@ export default function SectionProcedureScores({
           })}
         </ul>
       </div>
+
+      <ProcedureGuideModal
+        open={guideOpen}
+        onClose={() => setGuideOpen(false)}
+        initialProcedure={selectedProcedure}
+      />
     </div>
   );
 }

--- a/src/components/debt-relief/result/SectionRepaymentPlan.tsx
+++ b/src/components/debt-relief/result/SectionRepaymentPlan.tsx
@@ -251,7 +251,7 @@ function ExemptionAmount({ manwon }: { manwon: number }) {
   );
 }
 
-/** 면책 금액 한 묶음 — 라벨(이자 포함/원금 기준) + 금액 */
+/** 면책/잔여 금액 한 묶음 — 라벨(이자 포함/원금 기준) + 금액 */
 function ExemptionAmountBlock({ label, manwon }: { label: string; manwon: number }) {
   return (
     <div className="flex flex-col gap-2">
@@ -269,7 +269,7 @@ function ExemptionBoxes({
   remainingSubtitle: string;
 }) {
   // 이자 포함 값은 채무 상세입력 모드 건에만 존재 — 있으면 이자 포함·원금 기준을
-  // gap 25px로 나란히 병기. 없으면 원금 기준만 표시(2026-08 피그마).
+  // gap 16px로 나란히 병기. 없으면 원금 기준만 표시(2026-08 피그마).
   const hasInterest = plan.exemptedDebtWithInterestManwon != null;
 
   return (
@@ -277,12 +277,13 @@ function ExemptionBoxes({
     // 이자 병기 시 좌측(이자+원금)이 더 넓어지므로 flex 비율을  asymmetric 하게 둔다.
     <div className="rounded-[12px] bg-neutral-10 px-6 md:px-8 lg:pl-11 py-5 lg:py-6 flex items-stretch gap-4 sm:gap-0 min-h-[99px] lg:min-h-[118px]">
       <div
-        className={`min-w-0 flex flex-col gap-[6px] ${
+        className={`min-w-0 flex flex-col gap-[10px] ${
           hasInterest ? "flex-[1.6]" : "flex-1"
         }`}
       >
         <p className="text-[14px] font-medium leading-[17px] text-neutral-70">예상 면책 채무</p>
-        <div className="flex flex-wrap items-end gap-x-[25px] gap-y-3">
+        {/* gap-x는 "이자 포함" 값이 길어질 때 옆 칸("원금 기준")과 개행되지 않도록 25px보다 좁힘 */}
+        <div className="flex flex-wrap items-end gap-x-4 gap-y-3">
           {hasInterest && (
             <ExemptionAmountBlock
               label="이자 포함"
@@ -302,14 +303,13 @@ function ExemptionBoxes({
         aria-hidden
       />
 
-      <div className="flex-1 min-w-0 flex flex-col gap-[6px]">
+      <div className="flex-1 min-w-0 flex flex-col gap-[10px]">
         <p className="text-[14px] font-medium leading-[17px] text-neutral-70">예상 잔여 채무</p>
-        {/* 라벨이 없어 요소가 적으므로 타이틀·설명 사이 세로 가운데에 금액을 둔다 */}
-        <div className="flex-1 flex items-center">
-          <ExemptionAmount manwon={plan.totalPaymentManwon} />
-        </div>
+        {/* 잔여 채무는 이자 포함 값이 아예 없는 항목(RepaymentPlan에 필드 자체가 없음)이라
+            항상 원금 기준 — 좌측과 같은 라벨을 붙여 여백도 채우고 정렬도 맞춘다. */}
+        <ExemptionAmountBlock label="원금 기준" manwon={plan.totalPaymentManwon} />
         {remainingSubtitle && (
-          <p className="text-[13px] font-medium leading-4 text-neutral-50">
+          <p className="text-[13px] font-medium leading-4 text-neutral-50 mt-auto">
             {remainingSubtitle}
           </p>
         )}

--- a/src/services/debtRelief.ts
+++ b/src/services/debtRelief.ts
@@ -439,6 +439,16 @@ function toAnalysisFormInput(form: DiagnosisFormState): AnalysisFormInput {
     hasTaxArrears: form.hasTaxArrears,
     hasRecentAssetDisposal: form.hasRecentAssetDisposal,
     isOperatingBusiness: form.isOperatingBusiness,
+    // 새출발기금 상세 4종은 사업 영위 이력이 없으면 의미가 없어 아예 보내지 않는다(값은
+    // 폼 상태에 남겨둬 토글을 다시 켰을 때 입력값이 사라지지 않게 한다).
+    ...(form.isOperatingBusiness
+      ? {
+          businessOperationStatus: form.businessOperationStatus ?? undefined,
+          freshStartFundInsolvencyReasons: form.freshStartFundInsolvencyReasons,
+          isExcludedIndustryForFreshStartFund: form.isExcludedIndustryForFreshStartFund,
+          hasPreviousFreshStartFundApplication: form.hasPreviousFreshStartFundApplication,
+        }
+      : {}),
     specialEligibilities: form.specialEligibility.map((item) => SPECIAL_ELIGIBILITY_TO_ANALYSIS[item]),
     additionalNotes: form.counselorMemo || undefined,
   };
@@ -511,6 +521,10 @@ export function fromAnalysisFormInput(input: AnalysisInputData): DiagnosisFormSt
       transportation: input.fixedExpenses.transportCost ?? 0,
       other: input.fixedExpenses.otherFixedCost ?? 0,
     },
+    businessOperationStatus: input.businessOperationStatus ?? null,
+    freshStartFundInsolvencyReasons: input.freshStartFundInsolvencyReasons ?? [],
+    isExcludedIndustryForFreshStartFund: input.isExcludedIndustryForFreshStartFund ?? false,
+    hasPreviousFreshStartFundApplication: input.hasPreviousFreshStartFundApplication ?? false,
     hasPreviousApplication: input.hasPreviousBankruptcy,
     previousApplicationDetail: input.previousBankruptcyNote ?? "",
     hasGuarantor: input.hasGuarantorRelation,

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -133,6 +133,8 @@ export type AnalysisDebtItem = {
   /** 프론트에서 생성한 임의 ID (수정 시 항목 식별용) */
   id: string;
   debtType: AnalysisDebtItemType;
+  /** 담보대출 여부 */
+  isCollateralLoan: boolean;
   creditorName: string;
   repaymentMethod: AnalysisRepaymentMethod;
   overdueMonths: number;
@@ -165,6 +167,22 @@ export type AnalysisSpecialEligibility =
   | "over_65"
   | "severe_disability"
   | "jeonse_fraud_victim";
+
+// 2026-08-05 스펙 추가: 새출발기금 상세 항목. isOperatingBusiness가 true일 때만 의미있는 optional
+// 필드들 — 백엔드가 isExcludedIndustryForFreshStartFund/hasPreviousFreshStartFundApplication 중
+// 하나라도 true면 새출발기금을 결과 후보에서 자동 제외한다(프론트 별도 경고 불필요).
+export type AnalysisBusinessOperationStatus =
+  | "operating"
+  | "suspended"
+  | "closed_individual"
+  | "closed_corporate";
+
+export type AnalysisFreshStartFundInsolvencyReason =
+  | "overdue_3_months"
+  | "maturity_extension_or_payment_deferral"
+  | "tax_arrears"
+  | "low_credit_score"
+  | "not_applicable";
 
 // ============================================
 // 분석 생성/수정 입력
@@ -207,6 +225,11 @@ export type AnalysisFormInput = {
   hasRecentAssetDisposal?: boolean;
   /** 사업 영위 여부(현재 또는 과거). 새출발기금 후보 게이트 — 필수값이라 누락 시 400 */
   isOperatingBusiness: boolean;
+  /** isOperatingBusiness가 true일 때만 의미있는 optional 필드 4종 */
+  businessOperationStatus?: AnalysisBusinessOperationStatus;
+  freshStartFundInsolvencyReasons?: AnalysisFreshStartFundInsolvencyReason[];
+  isExcludedIndustryForFreshStartFund?: boolean;
+  hasPreviousFreshStartFundApplication?: boolean;
   specialEligibilities: AnalysisSpecialEligibility[]; // 없으면 []
   additionalNotes?: string;
 };
@@ -371,7 +394,7 @@ export type AnalysisResult = {
   expectedRepayment: AnalysisExpectedRepaymentMap;
   precautions: string[];
   consultingScripts: AnalysisConsultingScripts;
-  // 개인회생 선택 시에만 노출되는 "채무조정 비교" 섹션 문구. 1~3문장, **강조** 마크업 포함 가능.
+  // 개인회생 선택 시에만 노출되는 "개인회생과 개인워크아웃 비교" 섹션 문구. 1~3문장, **강조** 마크업 포함 가능.
   debtAdjustmentComparison?: string | null;
 };
 

--- a/src/types/debtRelief.ts
+++ b/src/types/debtRelief.ts
@@ -1,9 +1,11 @@
 // 회생·파산 진단 도메인 타입
 
 import type {
+  AnalysisBusinessOperationStatus,
   AnalysisDebtInputMode,
   AnalysisDebtItem,
   AnalysisDebtItemType,
+  AnalysisFreshStartFundInsolvencyReason,
   AnalysisInputData,
   AnalysisProcedureType,
   AnalysisRepaymentMethod,
@@ -411,6 +413,7 @@ export function createEmptyDebtItem(id: string): DebtItemFormState {
   return {
     id,
     debtType: "bank_loan",
+    isCollateralLoan: false,
     creditorName: "",
     repaymentMethod: "equal_principal_and_interest",
     overdueMonths: 0,
@@ -497,6 +500,25 @@ export const SPECIAL_ELIGIBILITY_OPTIONS: PillOption<SpecialEligibilityType>[] =
   { value: "jeonse_fraud_victim", label: "전세사기 피해자" },
 ];
 
+// 2026-08-05: 새출발기금 상세 항목 — isOperatingBusiness가 true일 때만 노출되는 하위 4종.
+// API enum과 로컬 폼 값이 1:1로 같아 별도 FROM/TO 변환表 없이 AnalysisXxx 타입을 그대로 쓴다
+// (debtInputMode/housingType 등과 동일한 패턴).
+export const BUSINESS_OPERATION_STATUS_OPTIONS: PillOption<AnalysisBusinessOperationStatus>[] = [
+  { value: "operating", label: "영업중" },
+  { value: "suspended", label: "휴업" },
+  { value: "closed_individual", label: "폐업(개인)" },
+  { value: "closed_corporate", label: "법인 폐업" },
+];
+
+// "해당없음"은 다른 항목과 상호배타 — Step5Others.tsx의 핸들러에서 처리.
+export const FRESH_START_FUND_INSOLVENCY_REASON_OPTIONS: PillOption<AnalysisFreshStartFundInsolvencyReason>[] = [
+  { value: "overdue_3_months", label: "3개월 이상 연체" },
+  { value: "maturity_extension_or_payment_deferral", label: "만기연장·상환유예" },
+  { value: "tax_arrears", label: "국세·지방세 체납" },
+  { value: "low_credit_score", label: "신용평점 하위" },
+  { value: "not_applicable", label: "해당없음" },
+];
+
 // ── 폼 전체 상태 ─────────────────────────────────────────────
 export type DiagnosisFormState = {
   // 1. 기본정보
@@ -542,6 +564,11 @@ export type DiagnosisFormState = {
   expenses: MonthlyExpenses;
 
   // 5. 기타사항
+  /** 새출발기금 상세 4종 — isOperatingBusiness가 true일 때만 의미있음(제출 시 services/debtRelief.ts에서 조건부 전송) */
+  businessOperationStatus: AnalysisBusinessOperationStatus | null;
+  freshStartFundInsolvencyReasons: AnalysisFreshStartFundInsolvencyReason[];
+  isExcludedIndustryForFreshStartFund: boolean;
+  hasPreviousFreshStartFundApplication: boolean;
   hasPreviousApplication: boolean;
   previousApplicationDetail: string;
   hasGuarantor: boolean;
@@ -583,6 +610,10 @@ export function createEmptyDiagnosisForm(): DiagnosisFormState {
     monthlyIncome: null,
     housingType: null,
     expenses: { housing: 0, food: 0, education: 0, transportation: 0, other: 0 },
+    businessOperationStatus: null,
+    freshStartFundInsolvencyReasons: [],
+    isExcludedIndustryForFreshStartFund: false,
+    hasPreviousFreshStartFundApplication: false,
     hasPreviousApplication: false,
     previousApplicationDetail: "",
     hasGuarantor: false,
@@ -769,7 +800,7 @@ export type DiagnosisDetail = {
   // 자격 게이트를 통과하지 못한 절차(예: 사업 미영위 시 새출발기금)는 키가 없다.
   conditionAnalysisByProcedure: Partial<Record<RecommendedProcedure, ConditionItem[]>>;
   debtStatus: DebtStatusSummary;
-  // 개인회생 추적 시에만 노출되는 "채무조정 비교" 문구 (없으면 null — 섹션 자체를 숨김)
+  // 개인회생 추적 시에만 노출되는 "개인회생과 개인워크아웃 비교" 문구 (없으면 null — 섹션 자체를 숨김)
   debtAdjustmentComparison: string | null;
   // 절차별 예상 변제 계획 — "절차별 성공 가능성"에서 선택된 절차 기준으로 SectionRepaymentPlan이
   // 조회한다. 신속채무조정·프리워크아웃은 백엔드가 항상 null로 내려주는 절차라 애초에 키가 없다


### PR DESCRIPTION
- 기타사항 스텝에 새출발기금 특례기간·사업상태·부실사유 등 상세 항목 추가
- 채무 항목에 담보대출 여부 필드 추가, 담보/무담보/총 합산 카드로 테이블 개편
- 절차별 조건 분석에 제도 안내 모달(ProcedureGuideModal) 연결
- DatePicker 텍스트 입력 시 자릿수 채워지는 대로 자동 포맷팅
- "채무조정 비교" 문구를 "개인회생과 개인워크아웃 비교"로 명확화