### PR TITLE
design: 채무 상세 모달·채무내역 카드 모바일 레이아웃 대응

### DIFF
--- a/src/components/debt-relief/form/DebtHistoryCard.tsx
+++ b/src/components/debt-relief/form/DebtHistoryCard.tsx
@@ -42,7 +42,7 @@ function DebtModeToggle({
     <div
       role="tablist"
       aria-label="채무 입력 방식"
-      className="flex h-12 w-[212px] shrink-0 items-center gap-3 rounded-[12px] bg-neutral-20 px-3 py-[8.5px]"
+      className="flex h-12 w-full md:w-[212px] shrink-0 items-center gap-3 rounded-[12px] bg-neutral-20 px-3 py-[8.5px]"
     >
       <button
         type="button"
@@ -50,7 +50,7 @@ function DebtModeToggle({
         aria-selected={value === "simple"}
         disabled={disabled}
         onClick={() => onChange("simple")}
-        className={`inline-flex h-[31px] w-[88px] cursor-pointer items-center justify-center whitespace-nowrap rounded-[5px] text-[16px] leading-[19px] transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
+        className={`inline-flex h-[31px] flex-1 md:w-[88px] md:flex-none cursor-pointer items-center justify-center whitespace-nowrap rounded-[5px] text-[16px] leading-[19px] transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
           value === "simple"
             ? "bg-white font-bold text-neutral-90 shadow-sm dark:bg-neutral-10"
             : "font-medium text-neutral-60 hover:text-foreground"
@@ -64,7 +64,7 @@ function DebtModeToggle({
         aria-selected={value === "detailed"}
         disabled={disabled}
         onClick={() => onChange("detailed")}
-        className={`inline-flex h-[31px] w-[88px] cursor-pointer items-center justify-center whitespace-nowrap rounded-[5px] text-[16px] leading-[19px] transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
+        className={`inline-flex h-[31px] flex-1 md:w-[88px] md:flex-none cursor-pointer items-center justify-center whitespace-nowrap rounded-[5px] text-[16px] leading-[19px] transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
           value === "detailed"
             ? "bg-white font-bold text-neutral-90 shadow-sm dark:bg-neutral-10"
             : "font-medium text-neutral-60 hover:text-foreground"
@@ -121,7 +121,7 @@ export default function DebtHistoryCard({
   return (
     // min-w-0: 상세모드 테이블(가로스크롤)이 flex 조상의 min-content 폭을 밀어올리지 않게
     <div className="min-w-0 overflow-hidden rounded-[14px] border border-neutral-30">
-      <div className="flex h-[70px] items-center justify-between gap-4 bg-neutral-10 px-5 md:px-6">
+      <div className="flex flex-col md:flex-row md:h-[70px] items-stretch md:items-center justify-between gap-3 md:gap-4 bg-neutral-10 px-5 py-4 md:py-0 md:px-6">
         <div className="min-w-0">
           <h3 className="text-[16px] font-bold leading-5 text-foreground">채무내역</h3>
           <p className="mt-1.5 text-[13px] leading-4 text-neutral-60">

--- a/src/components/debt-relief/form/DebtItemsTable.tsx
+++ b/src/components/debt-relief/form/DebtItemsTable.tsx
@@ -380,7 +380,7 @@ export default function DebtItemsTable({
         </table>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 p-3 border-t border-neutral-30">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3 p-3 border-t border-neutral-30">
         <DebtSumCard
           label="담보대출 합산"
           sums={collateralTotals}

--- a/src/components/debt-relief/result/DebtDetailModal.tsx
+++ b/src/components/debt-relief/result/DebtDetailModal.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import BaseModal from "@/components/common/BaseModal";
+import ChevronLeftIcon from "@/components/common/icons/ChevronLeftIcon";
 import AnalysisLoadingOverlayHost, {
   type AnalysisProgressHandle,
 } from "@/components/debt-relief/form/AnalysisLoadingOverlayHost";
@@ -162,10 +163,29 @@ export default function DebtDetailModal({
         onClose={handleClose}
         closeOnOverlayClick={!submitting && !choiceOpen}
         overlayClassName="bg-black/50 dark:bg-[#000000CC]"
-        containerClassName="relative w-[92vw] max-w-[1100px] max-h-[90vh] rounded-[14px] bg-white dark:bg-neutral-10 shadow-[0px_13px_61px_rgba(169,169,169,0.366)] dark:shadow-none flex flex-col overflow-hidden"
         ariaLabel="채무 상세"
+        fullScreenOnMobile
+        disableAutoContainerSizing
+        // 모바일: 바깥 여백 없이 화면 전체를 채우는 풀스크린 모달. md+: 기존처럼 중앙에 뜨는 카드형 모달.
+        positionerClassName="h-full p-0 md:h-auto md:min-h-full md:flex md:items-center md:justify-center md:p-4"
+        containerClassName="relative w-full h-full rounded-none md:w-[92vw] md:max-w-[1100px] md:max-h-[90vh] md:rounded-[14px] bg-white dark:bg-neutral-10 shadow-[0px_13px_61px_rgba(169,169,169,0.366)] dark:shadow-none flex flex-col overflow-hidden"
       >
-        <div className="flex items-center justify-between px-6 md:px-7 pt-6 pb-4 shrink-0">
+        {/* 모바일: 뒤로가기 화살표 + 타이틀 (풀스크린 페이지 헤더) */}
+        <div className="flex md:hidden items-center gap-3 px-5 pt-5 pb-4 shrink-0">
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={submitting}
+            aria-label="닫기"
+            className="cursor-pointer grid h-6 w-6 place-items-center disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <ChevronLeftIcon />
+          </button>
+          <h2 className="text-[18px] font-semibold text-ink dark:text-neutral-90">채무 상세</h2>
+        </div>
+
+        {/* md+: 타이틀 + X 닫기 */}
+        <div className="hidden md:flex items-center justify-between px-6 md:px-7 pt-6 pb-4 shrink-0">
           <h2 className="text-[18px] font-semibold text-ink dark:text-neutral-90">채무 상세</h2>
           <button
             type="button"
@@ -189,12 +209,12 @@ export default function DebtDetailModal({
           />
         </div>
 
-        <div className="flex justify-end gap-3 px-6 md:px-7 py-4 border-t border-neutral-30 dark:border-[#4D4D4D] shrink-0">
+        <div className="flex gap-3 px-5 md:px-7 py-4 border-t border-neutral-30 dark:border-[#4D4D4D] shrink-0 md:justify-end">
           <button
             type="button"
             onClick={handleClose}
             disabled={submitting}
-            className="cursor-pointer h-[34px] px-4 rounded-[5px] border border-neutral-30 dark:border-[#4D4D4D] bg-white dark:bg-neutral-10 text-[14px] font-semibold text-ink dark:text-neutral-90 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="cursor-pointer h-11 md:h-[34px] flex-1 md:flex-none px-4 rounded-[5px] border border-neutral-30 dark:border-[#4D4D4D] bg-white dark:bg-neutral-10 text-[14px] font-semibold text-ink dark:text-neutral-90 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             닫기
           </button>
@@ -203,7 +223,7 @@ export default function DebtDetailModal({
               type="button"
               onClick={handleApplyClick}
               disabled={submitting}
-              className="cursor-pointer h-[34px] px-4 rounded-[5px] bg-neutral-90 text-neutral-20 text-[14px] font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
+              className="cursor-pointer h-11 md:h-[34px] flex-1 md:flex-none px-4 rounded-[5px] bg-neutral-90 text-neutral-20 text-[14px] font-semibold disabled:opacity-50 disabled:cursor-not-allowed"
             >
               적용하기
             </button>


### PR DESCRIPTION
모바일에서 채무 상세 모달을 바깥 여백 없는 풀스크린으로 전환하고 뒤로가기
헤더/전폭 버튼을 적용. 채무내역 카드(분석 신규·수정 폼과 공유)는 토글을
세로 스택+전폭으로, 담보/무담보 합산 카드는 커스텀 sm 브레이크포인트
(375px)로 인해 모바일에서도 3열로 붙던 것을 md 기준으로 바로잡음.