### PR TITLE
feat: 분석 신규 API 필드 반영 및 채무 상세 입력 검증 보강

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -105,7 +105,9 @@
       "Bash(awk '/overflow-x: clip/{print; found=1} found && /^commit /{print \"FOUNDCOMMIT:\"$0; exit}')",
       "PowerShell(npx eslint src/hooks/useFakeProgress.ts src/app/test/AnalysisProgressPlayground.tsx src/app/test/page.tsx src/components/debt-relief/form/AnalysisLoadingOverlay.tsx src/components/debt-relief/form/analysisProgress.ts src/components/debt-relief/form/DiagnosisFormContent.tsx)",
       "PowerShell(node -p \"const p=require\\('./package.json'\\); JSON.stringify\\({react:p.dependencies.react, next:p.dependencies.next},null,1\\)\")",
-      "Bash(grep -n \"const { value, onChange\" src/components/common/DatePicker.tsx)"
+      "Bash(grep -n \"const { value, onChange\" src/components/common/DatePicker.tsx)",
+      "Read(//c/2026/ggosoonbox/.claude/**)",
+      "Read(//c/2026/**)"
     ]
   }
 }

--- a/src/components/debt-relief/form/DebtHistoryCard.tsx
+++ b/src/components/debt-relief/form/DebtHistoryCard.tsx
@@ -10,6 +10,7 @@ import {
 import { FormField, ManwonInput, MonthsInput } from "./FormControls";
 import { PillMultiSelect } from "./PillSelect";
 import DebtItemsTable from "./DebtItemsTable";
+import type { OverLimitDebtField } from "./validateDiagnosisForm";
 
 // ── 「채무내역」 카드 — 신규 폼(Step3)과 결과 화면 채무 상세 모달이 공유 ────────
 // form.debtInputMode를 그대로 토글에 연결한다 — 상세모드로 전환해도 간편모드 값
@@ -85,6 +86,12 @@ export type DebtHistoryCardProps = {
       neutral-10 그대로 두고, 모달처럼 컨테이너 자체가 이미 neutral-10인 곳에서는 묻히지 않도록
       호출부에서 오버라이드한다. */
   areaBackgroundClassName?: string;
+  /** 제출을 한 번 시도해 상세모드 채무 항목의 대출일·만기일·금액·금리 중 비어있는 값이
+      발견됐으면 true. 상세모드 테이블에만 영향을 준다. */
+  showDebtItemFieldErrors?: boolean;
+  /** 담보부채무·최근 3/6개월·1년 내 채무액 중 합계 초과로 판정된 필드 (빨간 테두리 표시).
+      결과화면 채무 상세 모달은 이 검사를 하지 않아 기본값(빈 배열)을 그대로 쓴다. */
+  overLimitFields?: OverLimitDebtField[];
 };
 
 export default function DebtHistoryCard({
@@ -93,6 +100,8 @@ export default function DebtHistoryCard({
   totalDebtManwon,
   disabled = false,
   areaBackgroundClassName = "bg-neutral-10",
+  showDebtItemFieldErrors = false,
+  overLimitFields = [],
 }: DebtHistoryCardProps) {
   const handleModeChange = (mode: DebtDisplayMode) => {
     if (disabled) return;
@@ -136,13 +145,14 @@ export default function DebtHistoryCard({
       </div>
 
       <div
-        className={`px-5 md:px-6 py-5 md:py-6 ${disabled ? "pointer-events-none opacity-80" : ""}`}
+        className={`flex flex-col gap-5 px-5 md:px-6 py-5 md:py-6 ${disabled ? "pointer-events-none opacity-80" : ""}`}
       >
         {form.debtInputMode === "detailed" ? (
           <DebtItemsTable
             debts={form.debts}
             onChange={(debts) => update("debts", debts)}
             sumCardBackgroundClassName={areaBackgroundClassName}
+            showFieldErrors={showDebtItemFieldErrors}
           />
         ) : (
           <div className="flex flex-col gap-5">
@@ -205,6 +215,41 @@ export default function DebtHistoryCard({
             </FormField>
           </div>
         )}
+
+        {/* 채무 종류별 잔액과 무관하게 입력 방식(간편/상세)과 상관없이 항상 필요한 항목 —
+            2026-08-06: 기존에 카드 바깥에 있던 것을 「채무내역」 카드 안으로 이동. */}
+        <div role="separator" className="h-px bg-neutral-30" />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-7 gap-y-4 md:gap-y-5">
+          <FormField label="최근 3개월 내 채무액" filled={form.recentDebtWithin3Months > 0}>
+            <ManwonInput
+              value={form.recentDebtWithin3Months}
+              onChange={(value) => update("recentDebtWithin3Months", value)}
+              invalid={overLimitFields.includes("recentDebtWithin3Months")}
+            />
+          </FormField>
+          <FormField label="최근 6개월 내 채무액" filled={form.recentDebtWithin6Months > 0}>
+            <ManwonInput
+              value={form.recentDebtWithin6Months}
+              onChange={(value) => update("recentDebtWithin6Months", value)}
+              invalid={overLimitFields.includes("recentDebtWithin6Months")}
+            />
+          </FormField>
+          <FormField label="최근 1년 내 채무액" filled={form.recentDebtWithin1Year > 0}>
+            <ManwonInput
+              value={form.recentDebtWithin1Year}
+              onChange={(value) => update("recentDebtWithin1Year", value)}
+              invalid={overLimitFields.includes("recentDebtWithin1Year")}
+            />
+          </FormField>
+          <FormField label="담보부채무" filled={form.securedDebt > 0}>
+            <ManwonInput
+              value={form.securedDebt}
+              onChange={(value) => update("securedDebt", value)}
+              invalid={overLimitFields.includes("securedDebt")}
+            />
+          </FormField>
+        </div>
       </div>
     </div>
   );

--- a/src/components/debt-relief/form/DebtItemsTable.tsx
+++ b/src/components/debt-relief/form/DebtItemsTable.tsx
@@ -11,6 +11,7 @@ import {
   createEmptyDebtItem,
   type DebtItemFormState,
 } from "@/types/debtRelief";
+import { getMissingDebtItemFields } from "./validateDiagnosisForm";
 import { PercentInput, TextInput, WonInput } from "./FormControls";
 
 type Props = {
@@ -19,6 +20,9 @@ type Props = {
   /** 담보/무담보 합산 카드 배경. 기본(신규 폼)은 카드 배경(neutral-0)과 대비되는 neutral-10 그대로 두고,
       모달처럼 컨테이너 자체가 이미 neutral-10인 곳에서는 묻히지 않도록 호출부에서 오버라이드한다. */
   sumCardBackgroundClassName?: string;
+  /** 제출을 한 번 시도해 대출일·만기일·금액·금리 중 비어있는 값이 발견됐으면 true.
+      이후 값이 채워지면 매 렌더마다 재계산되어 해당 셀만 즉시 해제된다. */
+  showFieldErrors?: boolean;
 };
 
 // "YYYY-MM-DD" ↔ 로컬 Date. new Date(isoString)은 UTC로 해석돼 시간대에 따라 하루 밀릴 수
@@ -49,6 +53,13 @@ const OVERDUE_MAX_DIGITS = 3;
 // 아래 공유 컨트롤(SelectField/TextInput/DatePicker/WonInput/PercentInput)의 기본 테두리는
 // 다른 화면(표 밖 폼)에서는 그대로 필요하므로, 테이블 셀에서만 이 클래스로 덮어쓴다.
 const CELL_INPUT_BORDERLESS = "!border-transparent focus:!border-neutral-30";
+
+// invalid 상태에서는 CELL_INPUT_BORDERLESS의 "!border-transparent"를 걷어내 컨트롤 자체의
+// invalid 스타일(!border-danger-40)이 가려지지 않게 한다 — 두 !important 테두리 색을
+// 동시에 주면 어느 쪽이 이기는지 클래스 순서로 보장되지 않는다.
+function cellInputClassName(invalid: boolean): string {
+  return invalid ? "" : CELL_INPUT_BORDERLESS;
+}
 
 function OverdueMonthsInput({
   value,
@@ -193,6 +204,7 @@ export default function DebtItemsTable({
   debts,
   onChange,
   sumCardBackgroundClassName = "bg-neutral-10",
+  showFieldErrors = false,
 }: Props) {
   const { containerRef, dragScrollHandlers } = useHorizontalDragScroll<HTMLDivElement>();
 
@@ -250,7 +262,11 @@ export default function DebtItemsTable({
             </tr>
           </thead>
           <tbody>
-            {debts.map((debt) => (
+            {debts.map((debt) => {
+              const missingFields = showFieldErrors ? getMissingDebtItemFields(debt) : [];
+              const isFieldInvalid = (field: "loanDate" | "maturityDate" | "principalWon" | "interestRate") =>
+                missingFields.includes(field);
+              return (
               <tr key={debt.id} className="border-b-[0.4px] border-neutral-30 last:border-b-0">
                 <td className={BODY_CELL}>
                   <SelectField
@@ -316,7 +332,8 @@ export default function DebtItemsTable({
                       value={parseDateOnly(debt.loanDate)}
                       onChange={(date) => updateItem(debt.id, { loanDate: formatDateOnly(date) })}
                       allowTextInput
-                      className={`pr-8 ${CELL_INPUT_BORDERLESS}`}
+                      invalid={isFieldInvalid("loanDate")}
+                      className={`pr-8 ${cellInputClassName(isFieldInvalid("loanDate"))}`}
                     />
                     <CalendarInlineIcon className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none" />
                   </div>
@@ -327,7 +344,8 @@ export default function DebtItemsTable({
                       value={parseDateOnly(debt.maturityDate)}
                       onChange={(date) => updateItem(debt.id, { maturityDate: formatDateOnly(date) })}
                       allowTextInput
-                      className={`pr-8 ${CELL_INPUT_BORDERLESS}`}
+                      invalid={isFieldInvalid("maturityDate")}
+                      className={`pr-8 ${cellInputClassName(isFieldInvalid("maturityDate"))}`}
                     />
                     <CalendarInlineIcon className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 pointer-events-none" />
                   </div>
@@ -336,14 +354,16 @@ export default function DebtItemsTable({
                   <WonInput
                     value={debt.principalWon}
                     onChange={(value) => updateItem(debt.id, { principalWon: value })}
-                    className={CELL_INPUT_BORDERLESS}
+                    invalid={isFieldInvalid("principalWon")}
+                    className={cellInputClassName(isFieldInvalid("principalWon"))}
                   />
                 </td>
                 <td className={BODY_CELL}>
                   <PercentInput
                     value={debt.interestRate}
                     onChange={(value) => updateItem(debt.id, { interestRate: value })}
-                    className={CELL_INPUT_BORDERLESS}
+                    invalid={isFieldInvalid("interestRate")}
+                    className={cellInputClassName(isFieldInvalid("interestRate"))}
                   />
                 </td>
                 <td className={READONLY_CELL}>{debt.termMonths ? `${debt.termMonths}개월` : "-"}</td>
@@ -361,7 +381,8 @@ export default function DebtItemsTable({
                   </button>
                 </td>
               </tr>
-            ))}
+              );
+            })}
           </tbody>
           <tfoot>
             <tr className="border-t border-neutral-30">

--- a/src/components/debt-relief/form/DiagnosisFormContent.tsx
+++ b/src/components/debt-relief/form/DiagnosisFormContent.tsx
@@ -11,6 +11,7 @@ import LoadingSpinner from "@/components/common/LoadingSpinner";
 import { canEditDiagnosisInfo, type DiagnosisFormState } from "@/types/debtRelief";
 import { useDiagnosisForm } from "./useDiagnosisForm";
 import {
+  getMissingDebtItemFieldLabels,
   getMissingRequiredFieldLabels,
   isDiagnosisFormComplete,
   isDiagnosisFormDirty,
@@ -70,6 +71,10 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
   // true로 래치. Step3Debts가 이 값과 최신 폼 상태를 함께 계산해 여전히 초과 상태일 때만 필드
   // 테두리를 빨갛게 표시하고, 값이 다시 유효해지는 즉시(재계산 결과 false) 자동으로 해제된다.
   const [debtSumOverLimitChecked, setDebtSumOverLimitChecked] = useState(false);
+  // 분석하기 클릭 시 상세모드 채무 항목의 대출일·만기일·금액·금리 중 비어있는 값이 발견된 적이
+  // 있으면 true로 래치. 위 debtSumOverLimitChecked와 동일한 방식으로, 값이 채워지면 해당 셀만
+  // 즉시 해제된다.
+  const [debtItemFieldsMissingChecked, setDebtItemFieldsMissingChecked] = useState(false);
 
   const isEdit = Boolean(diagnosisId);
   const [loadingForm, setLoadingForm] = useState(isEdit);
@@ -245,6 +250,24 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
       return;
     }
 
+    // canAnalyze(=isDiagnosisFormComplete)에는 일부러 포함하지 않은 검사 — 새 채무 행은
+    // 항상 이 4개가 비어있는 상태로 시작해서, 포함시키면 버튼이 계속 비활성 상태에 갇혀
+    // 클릭 자체가 막힌다. validateDiagnosisForm.ts의 getMissingDebtFieldLabels 주석 참고.
+    const missingDebtItemFields = getMissingDebtItemFieldLabels(form);
+    if (missingDebtItemFields.length > 0) {
+      setDebtItemFieldsMissingChecked(true);
+      showErrorModal({
+        type: "info",
+        title: "알림",
+        headline: "채무 항목을 확인해주세요.",
+        description: `${missingDebtItemFields.join(", ")}이(가) 비어있는 채무 항목이 있습니다.`,
+        confirmText: "채무 현황 입력",
+        hideCancel: true,
+        onConfirm: () => goToStep(2),
+      });
+      return;
+    }
+
     if (isRecentAndSecuredDebtOverTotal(form, derived.totalDebtManwon)) {
       setDebtSumOverLimitChecked(true);
       showErrorModal({
@@ -316,6 +339,7 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
             update={update}
             derived={derived}
             debtSumOverLimitChecked={debtSumOverLimitChecked}
+            debtItemFieldsMissingChecked={debtItemFieldsMissingChecked}
           />
         );
       case "income":

--- a/src/components/debt-relief/form/FormControls.tsx
+++ b/src/components/debt-relief/form/FormControls.tsx
@@ -156,11 +156,13 @@ export function WonInput({
   onChange,
   placeholder = "0",
   className = "",
+  invalid = false,
 }: {
   value: number;
   onChange: (value: number) => void;
   placeholder?: string;
   className?: string;
+  invalid?: boolean;
 }) {
   return (
     <input
@@ -171,7 +173,7 @@ export function WonInput({
         onChange(digits ? parseInt(digits, 10) : 0);
       }}
       placeholder={placeholder}
-      className={`${INPUT_CLASS} text-right ${className}`}
+      className={`${INPUT_CLASS} text-right ${className} ${invalid ? "!border-danger-40 dark:!border-danger-40" : ""}`}
     />
   );
 }
@@ -188,11 +190,13 @@ export function PercentInput({
   onChange,
   placeholder = "0",
   className = "",
+  invalid = false,
 }: {
   value: number;
   onChange: (value: number) => void;
   placeholder?: string;
   className?: string;
+  invalid?: boolean;
 }) {
   const [editingText, setEditingText] = useState<string | null>(null);
   const displayValue = editingText ?? (value ? String(value) : "");
@@ -220,7 +224,7 @@ export function PercentInput({
         }}
         onBlur={() => setEditingText(null)}
         placeholder={placeholder}
-        className={`${INPUT_CLASS} pr-7 text-right ${className}`}
+        className={`${INPUT_CLASS} pr-7 text-right ${className} ${invalid ? "!border-danger-40 dark:!border-danger-40" : ""}`}
       />
       <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[14px] font-medium tracking-[-0.02em] text-neutral-60 pointer-events-none">
         %

--- a/src/components/debt-relief/form/Step3Debts.tsx
+++ b/src/components/debt-relief/form/Step3Debts.tsx
@@ -5,7 +5,7 @@ import {
   type DiagnosisDerivedValues,
   type DiagnosisFormState,
 } from "@/types/debtRelief";
-import { FormField, ManwonInput } from "./FormControls";
+import { FormField } from "./FormControls";
 import { PillMultiSelect } from "./PillSelect";
 import { FormToggleRow } from "./FormToggle";
 import { getOverLimitDebtFields } from "./validateDiagnosisForm";
@@ -15,21 +15,36 @@ type Props = {
   form: DiagnosisFormState;
   update: <K extends keyof DiagnosisFormState>(key: K, value: DiagnosisFormState[K]) => void;
   derived: DiagnosisDerivedValues;
-  // 분석하기 제출 시점에 담보부채무·최근 3개월/1년 내 채무액의 합이 총 채무 합계를 초과한 적이
+  // 분석하기 제출 시점에 담보부채무·최근 3/6개월/1년 내 채무액의 합이 총 채무 합계를 초과한 적이
   // 있으면 true. 이후 값이 다시 유효해지면(sum <= totalDebt) 매 렌더마다 재계산되어 즉시 해제된다.
   debtSumOverLimitChecked?: boolean;
+  // 분석하기 제출 시점에 상세모드 채무 항목의 대출일·만기일·금액·금리 중 비어있는 값이
+  // 발견된 적이 있으면 true. 이후 값이 채워지면 해당 셀만 즉시 해제된다.
+  debtItemFieldsMissingChecked?: boolean;
 };
 
-export default function Step3Debts({ form, update, derived, debtSumOverLimitChecked = false }: Props) {
+export default function Step3Debts({
+  form,
+  update,
+  derived,
+  debtSumOverLimitChecked = false,
+  debtItemFieldsMissingChecked = false,
+}: Props) {
   // 값 하나만으로 총 채무를 넘는 필드가 있으면 그 필드만 표시하고, 여러 필드의 조합으로만
-  // 초과하는 경우(원인을 특정할 수 없음)에는 세 필드 모두 표시한다 — getOverLimitDebtFields 참고.
+  // 초과하는 경우(원인을 특정할 수 없음)에는 네 필드 모두 표시한다 — getOverLimitDebtFields 참고.
   const overLimitFields = debtSumOverLimitChecked
     ? getOverLimitDebtFields(form, derived.totalDebtManwon)
     : [];
 
   return (
     <div className="flex flex-col gap-5">
-      <DebtHistoryCard form={form} update={update} totalDebtManwon={derived.totalDebtManwon} />
+      <DebtHistoryCard
+        form={form}
+        update={update}
+        totalDebtManwon={derived.totalDebtManwon}
+        showDebtItemFieldErrors={debtItemFieldsMissingChecked}
+        overLimitFields={overLimitFields}
+      />
 
       {/* 카드 바깥 공통 영역 — 채무 종류별 잔액과 무관하게 입력 방식 상관없이 항상 필요한 항목.
           「채무발생 원인」은 샘플사이트 기준 두 모드가 공유하는 필드라 카드 밖에 둔다. */}
@@ -37,32 +52,6 @@ export default function Step3Debts({ form, update, derived, debtSumOverLimitChec
         {/* 2026-08-04: 채권자 수는 화면에 노출하지 않는다 — 간편모드는 채무종류 배지 개수,
             상세모드는 채무 항목 테이블 행 개수를 분석 제출 시점(services/debtRelief.ts의
             toAnalysisFormInput)에 내부적으로 계산해서 보낼 뿐, 상담사가 확인/수정할 UI는 두지 않는다. */}
-
-        {/* 2026-07-24 피드백 추가 항목 — 만원 단위 숫자입력 3종. 채무종류별 금액 그리드와
-            동일하게 2열(md:grid-cols-2)로 배치 — 3번째 필드는 다음 줄로 넘어간다. */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-7 gap-y-4 md:gap-y-5">
-          <FormField label="최근 3개월 내 채무액" filled={form.recentDebtWithin3Months > 0}>
-            <ManwonInput
-              value={form.recentDebtWithin3Months}
-              onChange={(value) => update("recentDebtWithin3Months", value)}
-              invalid={overLimitFields.includes("recentDebtWithin3Months")}
-            />
-          </FormField>
-          <FormField label="최근 1년 내 채무액" filled={form.recentDebtWithin1Year > 0}>
-            <ManwonInput
-              value={form.recentDebtWithin1Year}
-              onChange={(value) => update("recentDebtWithin1Year", value)}
-              invalid={overLimitFields.includes("recentDebtWithin1Year")}
-            />
-          </FormField>
-          <FormField label="담보부채무" filled={form.securedDebt > 0}>
-            <ManwonInput
-              value={form.securedDebt}
-              onChange={(value) => update("securedDebt", value)}
-              invalid={overLimitFields.includes("securedDebt")}
-            />
-          </FormField>
-        </div>
 
         <FormField label="체납이력">
           <FormToggleRow

--- a/src/components/debt-relief/form/validateDiagnosisForm.ts
+++ b/src/components/debt-relief/form/validateDiagnosisForm.ts
@@ -1,11 +1,40 @@
-import type { DiagnosisFormState } from "@/types/debtRelief";
+import type { DebtItemFormState, DiagnosisFormState } from "@/types/debtRelief";
 import type { FormStepKey } from "./steps";
+
+export type MissingDebtItemField = "loanDate" | "maturityDate" | "principalWon" | "interestRate";
+
+const MISSING_DEBT_ITEM_FIELD_LABELS: Record<MissingDebtItemField, string> = {
+  loanDate: "대출일",
+  maturityDate: "만기일",
+  principalWon: "금액",
+  interestRate: "금리",
+};
+
+/**
+ * 상세모드 채무 항목 1건에서 비어있는 필드를 반환한다.
+ * 연체(개월)는 0이 "연체 없음"이라는 유효한 기본값이라 여기서 검사하지 않는다.
+ */
+export function getMissingDebtItemFields(debt: DebtItemFormState): MissingDebtItemField[] {
+  const missing: MissingDebtItemField[] = [];
+  if (!debt.loanDate) missing.push("loanDate");
+  if (!debt.maturityDate) missing.push("maturityDate");
+  if (!debt.principalWon) missing.push("principalWon");
+  if (!debt.interestRate) missing.push("interestRate");
+  return missing;
+}
 
 // 채무현황 스텝의 필수값은 입력 모드에 따라 달라진다.
 // - 간편(simple): 채무종류 선택 + 연체기간 직접 입력
 // - 상세(detailed): 채무 항목 1건 이상. 연체기간은 서버가 항목별 최대값으로 자동 계산하므로 받지 않는다.
 // 결과화면 「채무 상세」모달(DebtHistoryCard만 재사용, 채무발생 원인 UI가 없음)도 이 함수를
 // 그대로 써서 자기 화면에 없는 필드를 요구하지 않도록 한다 — 채무발생 원인은 별도로 검사한다.
+//
+// 대출일·만기일·금액·금리(getMissingDebtItemFieldLabels)는 일부러 여기 포함하지 않는다.
+// 이 함수는 isDiagnosisFormComplete → canAnalyze로 이어져 "분석하기" 버튼의 disabled를
+// 직접 결정하는데, 새 행은 항상 이 4개가 비어있는 상태로 시작해서(createEmptyDebtItem)
+// 포함시키면 버튼이 계속 비활성 상태에 갇혀 클릭 자체가 막히고, 그 안에서 modal을 띄우거나
+// 셀을 빨갛게 표시하는 로직에 도달할 수조차 없게 된다. 대신 handleAnalyze 안에서
+// canAnalyze 통과 후 별도로 검사해 모달+빨간 테두리를 띄운다(담보부채무 초과 검사와 동일한 방식).
 export function getMissingDebtFieldLabels(form: DiagnosisFormState): string[] {
   const missing: string[] = [];
   if (form.debtInputMode === "detailed") {
@@ -17,6 +46,16 @@ export function getMissingDebtFieldLabels(form: DiagnosisFormState): string[] {
     if (form.overdueMonths === null) missing.push("연체기간");
   }
   return missing;
+}
+
+/** 상세모드 채무 항목들 중 대출일·만기일·금액·금리가 비어있는 게 있으면 그 라벨들(중복 제거). */
+export function getMissingDebtItemFieldLabels(form: DiagnosisFormState): string[] {
+  if (form.debtInputMode !== "detailed") return [];
+  const missingItemFields = new Set<MissingDebtItemField>();
+  form.debts.forEach((debt) => {
+    getMissingDebtItemFields(debt).forEach((field) => missingItemFields.add(field));
+  });
+  return Array.from(missingItemFields, (field) => MISSING_DEBT_ITEM_FIELD_LABELS[field]);
 }
 
 // 실 API(POST /v1/analysis)가 필수로 요구하는 항목. 폼에서 null/빈 값일 수 있는 것만 검사한다.
@@ -79,16 +118,24 @@ export function getMissingRequiredFieldLabelsForStep(
   }
 }
 
-/** 담보부채무·최근 3개월/1년 내 채무액 합이 총 채무 합계(채무종류별 금액 합)를 넘는지 검사 */
+/** 담보부채무·최근 3개월/6개월/1년 내 채무액 합이 총 채무 합계(채무종류별 금액 합)를 넘는지 검사 */
 export function isRecentAndSecuredDebtOverTotal(
   form: DiagnosisFormState,
   totalDebtManwon: number
 ): boolean {
-  const sum = form.securedDebt + form.recentDebtWithin3Months + form.recentDebtWithin1Year;
+  const sum =
+    form.securedDebt +
+    form.recentDebtWithin3Months +
+    form.recentDebtWithin6Months +
+    form.recentDebtWithin1Year;
   return sum > totalDebtManwon;
 }
 
-export type OverLimitDebtField = "securedDebt" | "recentDebtWithin3Months" | "recentDebtWithin1Year";
+export type OverLimitDebtField =
+  | "securedDebt"
+  | "recentDebtWithin3Months"
+  | "recentDebtWithin6Months"
+  | "recentDebtWithin1Year";
 
 /**
  * 합계 초과 시 어떤 필드가 원인인지 최대한 특정한다. 한 필드의 값만으로도 총 채무를 넘는다면
@@ -105,6 +152,7 @@ export function getOverLimitDebtFields(
   const fields: { key: OverLimitDebtField; value: number }[] = [
     { key: "securedDebt", value: form.securedDebt },
     { key: "recentDebtWithin3Months", value: form.recentDebtWithin3Months },
+    { key: "recentDebtWithin6Months", value: form.recentDebtWithin6Months },
     { key: "recentDebtWithin1Year", value: form.recentDebtWithin1Year },
   ];
   const individuallyOverLimit = fields

--- a/src/components/debt-relief/result/DebtDetailModal.tsx
+++ b/src/components/debt-relief/result/DebtDetailModal.tsx
@@ -7,7 +7,10 @@ import AnalysisLoadingOverlayHost, {
   type AnalysisProgressHandle,
 } from "@/components/debt-relief/form/AnalysisLoadingOverlayHost";
 import DebtHistoryCard from "@/components/debt-relief/form/DebtHistoryCard";
-import { getMissingDebtFieldLabels } from "@/components/debt-relief/form/validateDiagnosisForm";
+import {
+  getMissingDebtFieldLabels,
+  getMissingDebtItemFieldLabels,
+} from "@/components/debt-relief/form/validateDiagnosisForm";
 import { showErrorModal } from "@/providers/ErrorFeedbackModalProvider";
 import {
   DebtReliefService,
@@ -72,6 +75,9 @@ export default function DebtDetailModal({
   const [form, setForm] = useState<DiagnosisFormState>(createEmptyDiagnosisForm);
   const [submittingAction, setSubmittingAction] = useState<"save" | "reanalyze" | null>(null);
   const [choiceOpen, setChoiceOpen] = useState(false);
+  // 적용하기 클릭 시 채무 항목의 대출일·만기일·금액·금리 중 비어있는 값이 발견된 적이 있으면
+  // true로 래치. DebtHistoryCard가 최신 폼 상태로 매 렌더마다 재계산해 값이 채워진 셀만 즉시 해제한다.
+  const [showDebtItemFieldErrors, setShowDebtItemFieldErrors] = useState(false);
   const submitting = submittingAction != null;
   // 재분석 대기 중 전체 화면 로딩으로 전환 — 진행률 상태는 오버레이 안에 가둬 잦은 갱신이
   // 이 모달 트리 전체를 리렌더하지 않게 한다(AnalysisLoadingOverlayHost 주석 참고).
@@ -90,6 +96,7 @@ export default function DebtDetailModal({
     setForm(fromAnalysisFormInput(detail.inputData));
     setSubmittingAction(null);
     setChoiceOpen(false);
+    setShowDebtItemFieldErrors(false);
   }, [open, detail.inputData]);
 
   const update = useCallback(
@@ -112,8 +119,9 @@ export default function DebtDetailModal({
   const handleApplyClick = () => {
     if (!canEdit || submitting) return;
 
-    const missing = getMissingDebtFieldLabels(form);
+    const missing = [...getMissingDebtFieldLabels(form), ...getMissingDebtItemFieldLabels(form)];
     if (missing.length > 0) {
+      setShowDebtItemFieldErrors(true);
       showErrorModal({
         headline: "필수 항목을 확인해 주세요.",
         description: "채무 정보를 모두 입력한 뒤 다시 시도해주세요.",
@@ -206,6 +214,7 @@ export default function DebtDetailModal({
             totalDebtManwon={totalDebtManwon}
             disabled={!canEdit || submitting}
             areaBackgroundClassName="bg-neutral-10 dark:bg-neutral-0"
+            showDebtItemFieldErrors={showDebtItemFieldErrors}
           />
         </div>
 

--- a/src/components/debt-relief/result/DiagnosisCustomerInfoModal.tsx
+++ b/src/components/debt-relief/result/DiagnosisCustomerInfoModal.tsx
@@ -10,7 +10,7 @@ import type {
   AnalysisVehicleValueRange,
 } from "@/types/analysis";
 import {
-  DEBT_CAUSE_OPTIONS,
+  DEBT_CAUSE_LABELS,
   DEBT_TYPE_OPTIONS,
   FINANCIAL_ASSET_OPTIONS,
   HOUSING_TYPE_OPTIONS,
@@ -51,6 +51,7 @@ const VEHICLE_FROM: Record<AnalysisVehicleValueRange, VehicleRange> = {
 };
 
 const INCOME_FROM: Record<AnalysisMonthlyIncomeRange, MonthlyIncomeRange> = {
+  none: "none",
   under_100: "under_100",
   "100_to_200": "100_200",
   "200_to_300": "200_300",
@@ -63,6 +64,7 @@ const DEBT_CAUSE_FROM: Record<string, DebtCause> = {
   living_expenses: "living_expenses",
   medical_expenses: "medical",
   investment_loss: "investment_loss",
+  gambling_or_speculative_investment_loss: "gambling_or_speculative_investment_loss",
   guarantee_damage: "guarantee_damage",
   other: "other",
 };
@@ -144,14 +146,14 @@ function debtTypesLabel(breakdown: AnalysisDebtBreakdown): string {
   return types.length > 0 ? types.join(", ") : "-";
 }
 
+// 선택 UI(DEBT_CAUSE_OPTIONS)에는 없는 레거시 값(investment_loss)도 읽기 전용 표시는 계속 필요해
+// DEBT_CAUSE_OPTIONS가 아니라 전체 라벨을 담은 DEBT_CAUSE_LABELS에서 찾는다.
 function debtCausesLabel(causes: string[]): string {
   if (!causes.length) return "-";
   return causes
     .map((cause) => {
       const mapped = DEBT_CAUSE_FROM[cause];
-      return mapped
-        ? DEBT_CAUSE_OPTIONS.find((o) => o.value === mapped)?.label ?? cause
-        : cause;
+      return mapped ? DEBT_CAUSE_LABELS[mapped] : cause;
     })
     .join(", ");
 }

--- a/src/components/debt-relief/result/SectionDebtStatus.tsx
+++ b/src/components/debt-relief/result/SectionDebtStatus.tsx
@@ -5,6 +5,20 @@ import type { DebtStatusSummary, DiagnosisDetail } from "@/types/debtRelief";
 import { formatManwonComma } from "@/components/debt-relief/format";
 import DebtDetailModal from "./DebtDetailModal";
 
+// "자세히 보기" 버튼의 돋보기 아이콘.
+function DebtDetailSearchIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
+      <path
+        d="M6.66667 13.3333L9.06557 10.9344M9.06557 10.9344C9.51798 11.3868 10.143 11.6667 10.8333 11.6667C12.214 11.6667 13.3333 10.5474 13.3333 9.16667C13.3333 7.78595 12.214 6.66667 10.8333 6.66667C9.45262 6.66667 8.33333 7.78595 8.33333 9.16667C8.33333 9.85702 8.61316 10.482 9.06557 10.9344ZM17.5 10C17.5 14.1421 14.1421 17.5 10 17.5C5.85786 17.5 2.5 14.1421 2.5 10C2.5 5.85786 5.85786 2.5 10 2.5C14.1421 2.5 17.5 5.85786 17.5 10Z"
+        className="stroke-[var(--secondary-20)] dark:stroke-blue-300"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
 function Metric({
   label,
   value,
@@ -52,8 +66,9 @@ export default function SectionDebtStatus({
           <button
             type="button"
             onClick={() => setDebtDetailOpen(true)}
-            className="cursor-pointer inline-flex items-center justify-center h-7 px-2.5 rounded-[5px] border border-neutral-30 bg-neutral-0 text-[13px] font-medium leading-4 tracking-[-0.02em] text-neutral-60 hover:bg-neutral-10 whitespace-nowrap"
+            className="cursor-pointer inline-flex items-center gap-1 h-[28px] px-2 py-1 rounded-[5px] border border-secondary-20 dark:border-secondary-40 bg-white dark:bg-neutral-10 text-[14px] font-semibold leading-[17px] tracking-[-0.02em] text-foreground hover:bg-neutral-10 dark:hover:bg-neutral-20 whitespace-nowrap"
           >
+            <DebtDetailSearchIcon />
             자세히 보기
           </button>
         </div>

--- a/src/components/debt-relief/result/SectionProcedureScores.tsx
+++ b/src/components/debt-relief/result/SectionProcedureScores.tsx
@@ -85,6 +85,20 @@ const STATUS_CHIP: Record<ConditionStatus, string> = {
   risk: "bg-danger-10 text-danger-40 dark:bg-danger-10/90 dark:text-danger-80",
 };
 
+// 절차별 성공 가능성 타이틀의 안내(i) 아이콘 옆에 붙는 "제도안내" 버튼의 돋보기 아이콘.
+function ProcedureGuideIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
+      <path
+        d="M6.66667 13.3333L9.06557 10.9344M9.06557 10.9344C9.51798 11.3868 10.143 11.6667 10.8333 11.6667C12.214 11.6667 13.3333 10.5474 13.3333 9.16667C13.3333 7.78595 12.214 6.66667 10.8333 6.66667C9.45262 6.66667 8.33333 7.78595 8.33333 9.16667C8.33333 9.85702 8.61316 10.482 9.06557 10.9344ZM17.5 10C17.5 14.1421 14.1421 17.5 10 17.5C5.85786 17.5 2.5 14.1421 2.5 10C2.5 5.85786 5.85786 2.5 10 2.5C14.1421 2.5 17.5 5.85786 17.5 10Z"
+        className="stroke-[var(--secondary-20)] dark:stroke-blue-300"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
 function ConditionIcon({ status }: { status: ConditionStatus }) {
   if (status === "met") {
     return (
@@ -415,6 +429,14 @@ export default function SectionProcedureScores({
             <br />
             법원·채권자 심사 결과를 보장하지 않습니다.
           </DisclaimerInfoTooltip>
+          <button
+            type="button"
+            onClick={() => setGuideOpen(true)}
+            className="cursor-pointer inline-flex items-center gap-1 h-[28px] px-2 py-1 rounded-[5px] border border-secondary-20 dark:border-secondary-40 bg-white dark:bg-neutral-10 text-[14px] font-semibold leading-[17px] tracking-[-0.02em] text-foreground whitespace-nowrap hover:bg-neutral-10 dark:hover:bg-neutral-20 shrink-0"
+          >
+            <ProcedureGuideIcon />
+            제도안내
+          </button>
         </div>
         <div className="mt-3 border-t border-neutral-30" />
       </div>
@@ -453,13 +475,6 @@ export default function SectionProcedureScores({
             <h3 className="text-[14px] font-semibold leading-[17px] tracking-[-0.02em] text-foreground truncate">
               {selectedScore?.label ?? detail.recommendation.title} 조건 분석
             </h3>
-            <button
-              type="button"
-              onClick={() => setGuideOpen(true)}
-              className="cursor-pointer inline-flex items-center justify-center h-[25px] px-2 py-1 rounded-[5px] border border-neutral-30 bg-white dark:bg-neutral-10 text-[14px] font-semibold leading-[17px] tracking-[-0.02em] text-foreground whitespace-nowrap hover:bg-neutral-10 dark:hover:bg-neutral-20 shrink-0"
-            >
-              제도안내
-            </button>
           </div>
           <div className="flex items-center gap-1.5 md:gap-2 shrink-0">
             {(["met", "caution", "risk"] as ConditionStatus[]).map((status) => (

--- a/src/components/debt-relief/result/SectionRepaymentPlan.tsx
+++ b/src/components/debt-relief/result/SectionRepaymentPlan.tsx
@@ -212,13 +212,22 @@ function RepaymentTimeline({
   );
 }
 
+// 2026-08-08: 가용소득이 사실상 없어 월 변제액이 0원으로 산출되는 케이스(개인회생/개인워크아웃 등)는
+// "0원"이 아니라 "산정 불가"로 표시하고, 기간·총액도 의미가 없으므로 "-"로 비운다.
 function PlanRowsPanel({ plan }: { plan: RepaymentPlan }) {
+  const isUnpayable = plan.monthlyPaymentManwon === 0;
   return (
     // pad 32×17, 행 간격 16
     <div className="rounded-[12px] border border-neutral-30 px-5 md:px-8 py-[17px] flex flex-col gap-4 lg:min-h-[118px]">
-      <PlanRow label="월 변제액" value={formatManwonComma(plan.monthlyPaymentManwon)} />
-      <PlanRow label="변제 기간" value={`${plan.months}개월 (${plan.years}년)`} />
-      <PlanRow label="총 변제액" value={formatManwonComma(plan.totalPaymentManwon)} />
+      <PlanRow
+        label="월 변제액"
+        value={isUnpayable ? "산정 불가" : formatManwonComma(plan.monthlyPaymentManwon)}
+      />
+      <PlanRow label="변제 기간" value={isUnpayable ? "-" : `${plan.months}개월 (${plan.years}년)`} />
+      <PlanRow
+        label="총 변제액"
+        value={isUnpayable ? "-" : formatManwonComma(plan.totalPaymentManwon)}
+      />
     </div>
   );
 }
@@ -495,14 +504,20 @@ export default function SectionRepaymentPlan({
       {kind === "full" && plan ? (
         // 피그마: 열 간격 28px, 행 간격 16px / 셀 620×118 — 그래프(타임라인)가 있는 절차만
         // 2x2 그리드(3행 패널+타임라인 / 면책·잔여 박스+주의사항)를 그대로 유지한다.
+        // 월 변제액이 0원(가용소득 사실상 없음)이면 타임라인·면책/잔여 박스는 보여줄 수치가 없으므로
+        // 아예 그리지 않는다 — PlanRowsPanel(산정 불가 표시)과 주의사항만 남는다.
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-x-[28px] lg:gap-y-4">
           <PlanRowsPanel plan={plan} />
-          <RepaymentTimeline
-            months={plan.months}
-            monthlyPaymentManwon={plan.monthlyPaymentManwon}
-            consultedAt={detail.consultedAt}
-          />
-          <ExemptionBoxes plan={plan} remainingSubtitle={REMAINING_DEBT_SUBTITLE.full} />
+          {plan.monthlyPaymentManwon > 0 && (
+            <RepaymentTimeline
+              months={plan.months}
+              monthlyPaymentManwon={plan.monthlyPaymentManwon}
+              consultedAt={detail.consultedAt}
+            />
+          )}
+          {plan.monthlyPaymentManwon > 0 && (
+            <ExemptionBoxes plan={plan} remainingSubtitle={REMAINING_DEBT_SUBTITLE.full} />
+          )}
           <PrecautionsList notes={detail.repaymentNotes} />
         </div>
       ) : (

--- a/src/services/debtRelief.ts
+++ b/src/services/debtRelief.ts
@@ -146,6 +146,7 @@ const VEHICLE_FROM_ANALYSIS: Record<AnalysisVehicleValueRange, VehicleRange> = {
 };
 
 const MONTHLY_INCOME_TO_ANALYSIS: Record<MonthlyIncomeRange, AnalysisMonthlyIncomeRange> = {
+  none: "none",
   under_100: "under_100",
   "100_200": "100_to_200",
   "200_300": "200_to_300",
@@ -154,6 +155,7 @@ const MONTHLY_INCOME_TO_ANALYSIS: Record<MonthlyIncomeRange, AnalysisMonthlyInco
 };
 
 const MONTHLY_INCOME_FROM_ANALYSIS: Record<AnalysisMonthlyIncomeRange, MonthlyIncomeRange> = {
+  none: "none",
   under_100: "under_100",
   "100_to_200": "100_200",
   "200_to_300": "200_300",
@@ -166,6 +168,7 @@ const DEBT_CAUSE_TO_ANALYSIS: Record<DebtCause, AnalysisDebtCause> = {
   living_expenses: "living_expenses",
   medical: "medical_expenses",
   investment_loss: "investment_loss",
+  gambling_or_speculative_investment_loss: "gambling_or_speculative_investment_loss",
   guarantee_damage: "guarantee_damage",
   other: "other",
 };
@@ -175,6 +178,7 @@ const DEBT_CAUSE_FROM_ANALYSIS: Record<AnalysisDebtCause, DebtCause> = {
   living_expenses: "living_expenses",
   medical_expenses: "medical",
   investment_loss: "investment_loss",
+  gambling_or_speculative_investment_loss: "gambling_or_speculative_investment_loss",
   guarantee_damage: "guarantee_damage",
   other: "other",
 };
@@ -422,6 +426,7 @@ function toAnalysisFormInput(form: DiagnosisFormState): AnalysisFormInput {
         }),
     collateralDebt: form.securedDebt,
     debtIncurredLast3Months: form.recentDebtWithin3Months,
+    debtIncurredLast6Months: form.recentDebtWithin6Months,
     debtIncurredLast1Year: form.recentDebtWithin1Year,
     debtCauses: form.debtCauses.map((cause) => DEBT_CAUSE_TO_ANALYSIS[cause]),
     realEstateBreakdown,
@@ -511,6 +516,7 @@ export function fromAnalysisFormInput(input: AnalysisInputData): DiagnosisFormSt
     hasTaxArrears: input.hasTaxArrears ?? false,
     securedDebt: input.collateralDebt ?? 0,
     recentDebtWithin3Months: input.debtIncurredLast3Months ?? 0,
+    recentDebtWithin6Months: input.debtIncurredLast6Months ?? 0,
     recentDebtWithin1Year: input.debtIncurredLast1Year ?? 0,
     monthlyIncome: MONTHLY_INCOME_FROM_ANALYSIS[input.monthlyIncomeRange] ?? null,
     housingType: input.housingType,
@@ -557,8 +563,10 @@ function toDiagnosisListItem(item: AnalysisListItem): DiagnosisListItem {
     gender: item.gender ?? undefined,
     occupation: item.employmentType ?? undefined,
     region: item.region,
-    totalDebtManwon: item.totalDebt,
-    monthlyAvailableIncomeManwon: item.disposableIncome,
+    // totalDebt/disposableIncome이 null/undefined로 내려오는 목록 건이 있어 방어(2026-08-08 런타임
+    // 에러 확인 — disposableIncome undefined로 formatAvailableIncome이 크래시).
+    totalDebtManwon: item.totalDebt ?? 0,
+    monthlyAvailableIncomeManwon: item.disposableIncome ?? 0,
     status: item.status,
     recommendedProcedure: item.procedure ? normalizeProcedureType(item.procedure) : undefined,
     feePlanSummary: item.feePlan,
@@ -1111,6 +1119,7 @@ export const DebtReliefService = {
           }),
       collateralDebt: form.securedDebt,
       debtIncurredLast3Months: form.recentDebtWithin3Months,
+      debtIncurredLast6Months: form.recentDebtWithin6Months,
       debtIncurredLast1Year: form.recentDebtWithin1Year,
       debtCauses: form.debtCauses.map((cause) => DEBT_CAUSE_TO_ANALYSIS[cause]),
       reanalyze,

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -55,7 +55,9 @@ export function normalizeProcedureType(
 
 export type AnalysisGender = "male" | "female";
 
+// 2026-08-06 스펙 확장: "none"(소득 없음, 추정 0만원) 추가.
 export type AnalysisMonthlyIncomeRange =
+  | "none"
   | "under_100"
   | "100_to_200"
   | "200_to_300"
@@ -68,11 +70,15 @@ export type AnalysisHousingType =
   | "monthly_rent"
   | "living_with_family";
 
+// 2026-08-06 스펙 확장: investment_loss(투자손실)를 대체하는 gambling_or_speculative_investment_loss
+// (도박/주식/코인) 추가. investment_loss는 하위호환을 위해 값은 유지되나 선택 UI에는 노출하지 않는다
+// (src/types/debtRelief.ts의 DEBT_CAUSE_OPTIONS/DEBT_CAUSE_LABELS 참고).
 export type AnalysisDebtCause =
   | "business_failure"
   | "living_expenses"
   | "medical_expenses"
   | "investment_loss"
+  | "gambling_or_speculative_investment_loss"
   | "guarantee_damage"
   | "other";
 
@@ -207,6 +213,7 @@ export type AnalysisFormInput = {
   debts?: AnalysisDebtItem[];
   collateralDebt: number; // 담보부 채무 (만원)
   debtIncurredLast3Months: number; // 최근 3개월 내 발생 채무액 (만원)
+  debtIncurredLast6Months: number; // 최근 6개월 내 발생 채무액 (만원). 2026-08-06 스펙 추가
   debtIncurredLast1Year: number; // 최근 1년 내 발생 채무액 (만원)
   /** 연체 개월 수(정수). simple 모드일 때 필수 — detailed는 서버가 debts 중 최대값으로 자동 계산 */
   overdueMonths?: number;
@@ -265,6 +272,7 @@ export type UpdateAnalysisDebtsInput = {
   debts?: AnalysisDebtItem[];
   collateralDebt: number;
   debtIncurredLast3Months: number;
+  debtIncurredLast6Months: number;
   debtIncurredLast1Year: number;
   /** simple일 때 필수. detailed는 서버가 debts 중 최대값으로 자동 계산 */
   overdueMonths?: number;
@@ -563,8 +571,11 @@ export type AnalysisListItem = {
   customerName: string;
   employmentType?: string | null;
   region: string;
-  totalDebt: number;
-  disposableIncome: number;
+  // 2026-08-08 실 응답 확인: totalDebt/disposableIncome 둘 다 타입상 number지만 특정 목록 건에서
+  // null/undefined로 내려오는 경우가 있다(원인 미확인) — toDiagnosisListItem에서 반드시 0으로
+  // 방어해서 도메인 타입(DiagnosisListItem)으로 넘긴다. 같은 응답의 같은 위치 필드라 동일 위험군.
+  totalDebt: number | null;
+  disposableIncome: number | null;
   // 백엔드가 trackingProcedure ?? analysisResult.recommendation ?? null 로 계산해 내려주는 단일 필드.
   // "절차진행중이면 현재 추적 절차, 그 이전 단계에서는 AI 추천 절차"를 항상 정확히 반영한다.
   procedure: AnalysisProcedureType | null;

--- a/src/types/debtRelief.ts
+++ b/src/types/debtRelief.ts
@@ -428,20 +428,40 @@ export function createEmptyDebtItem(id: string): DebtItemFormState {
   };
 }
 
+// 2026-08-06: investment_loss(투자손실)를 gambling_or_speculative_investment_loss(도박/주식/코인)로
+// 대체. 백엔드가 하위호환을 위해 investment_loss 값 자체는 계속 허용하지만, 신규 선택 UI(아래
+// DEBT_CAUSE_OPTIONS)에는 더 이상 노출하지 않는다 — 기존 값(과거 저장된 분석 건)의 읽기 전용
+// 표시에만 DEBT_CAUSE_LABELS로 라벨을 계속 붙인다.
 export type DebtCause =
   | "business_failure"
   | "living_expenses"
   | "medical"
   | "investment_loss"
+  | "gambling_or_speculative_investment_loss"
   | "guarantee_damage"
   | "other";
+
+/** 전체 라벨(레거시 값 포함) — 읽기 전용 표시 전용. 선택 UI는 DEBT_CAUSE_OPTIONS를 쓴다. */
+export const DEBT_CAUSE_LABELS: Record<DebtCause, string> = {
+  business_failure: "사업실패",
+  living_expenses: "생활비 부족",
+  medical: "의료비",
+  investment_loss: "투자손실",
+  gambling_or_speculative_investment_loss: "도박/주식/코인",
+  guarantee_damage: "보증피해",
+  other: "기타",
+};
+
 export const DEBT_CAUSE_OPTIONS: PillOption<DebtCause>[] = [
-  { value: "business_failure", label: "사업실패" },
-  { value: "living_expenses", label: "생활비 부족" },
-  { value: "medical", label: "의료비" },
-  { value: "investment_loss", label: "투자손실" },
-  { value: "guarantee_damage", label: "보증피해" },
-  { value: "other", label: "기타" },
+  { value: "business_failure", label: DEBT_CAUSE_LABELS.business_failure },
+  { value: "living_expenses", label: DEBT_CAUSE_LABELS.living_expenses },
+  { value: "medical", label: DEBT_CAUSE_LABELS.medical },
+  {
+    value: "gambling_or_speculative_investment_loss",
+    label: DEBT_CAUSE_LABELS.gambling_or_speculative_investment_loss,
+  },
+  { value: "guarantee_damage", label: DEBT_CAUSE_LABELS.guarantee_damage },
+  { value: "other", label: DEBT_CAUSE_LABELS.other },
 ];
 
 // 2026-08-04: 채권자 수는 더 이상 사용자가 직접 고르거나 화면에 노출하지 않는다.
@@ -451,8 +471,16 @@ export const DEBT_CAUSE_OPTIONS: PillOption<DebtCause>[] = [
 // 필수값으로 검증하므로 채권자 수가 0이 되는 경우는 존재하지 않아 별도 필수값 검사도 두지 않는다.
 
 // ── 4. 소득/지출 ─────────────────────────────────────────────
-export type MonthlyIncomeRange = "under_100" | "100_200" | "200_300" | "300_400" | "over_400";
+// 2026-08-06 스펙 확장: "none"(소득 없음) 추가 — 가장 왼쪽 옵션.
+export type MonthlyIncomeRange =
+  | "none"
+  | "under_100"
+  | "100_200"
+  | "200_300"
+  | "300_400"
+  | "over_400";
 export const MONTHLY_INCOME_OPTIONS: PillOption<MonthlyIncomeRange>[] = [
+  { value: "none", label: "소득 없음" },
   { value: "under_100", label: "100만 이하" },
   { value: "100_200", label: "100~200만" },
   { value: "200_300", label: "200~300만" },
@@ -460,8 +488,9 @@ export const MONTHLY_INCOME_OPTIONS: PillOption<MonthlyIncomeRange>[] = [
   { value: "over_400", label: "400만 이상" },
 ];
 
-// 월 소득 구간 → 추정 대표값 (만원, 구간 중앙값 기준)
+// 월 소득 구간 → 추정 대표값 (만원, 구간 중앙값 기준). none은 추정 0만원.
 export const MONTHLY_INCOME_ESTIMATE: Record<MonthlyIncomeRange, number> = {
+  none: 0,
   under_100: 80,
   "100_200": 150,
   "200_300": 250,
@@ -553,6 +582,7 @@ export type DiagnosisFormState = {
   // 대응(services/debtRelief.ts 참고).
   securedDebt: number; // 담보부채무 (만원)
   recentDebtWithin3Months: number; // 최근 3개월 내 채무액 (만원)
+  recentDebtWithin6Months: number; // 최근 6개월 내 채무액 (만원). 2026-08-06 스펙 추가
   recentDebtWithin1Year: number; // 최근 1년 내 채무액 (만원)
 
   // 4. 소득/지출
@@ -606,6 +636,7 @@ export function createEmptyDiagnosisForm(): DiagnosisFormState {
     hasTaxArrears: false,
     securedDebt: 0,
     recentDebtWithin3Months: 0,
+    recentDebtWithin6Months: 0,
     recentDebtWithin1Year: 0,
     monthlyIncome: null,
     housingType: null,


### PR DESCRIPTION
- 월 소득 구간에 "소득 없음"(none) 옵션 추가, 추정 월소득 0만원 처리
- 채무발생 원인 "투자손실"을 "도박/주식/코인"(gambling_or_speculative_investment_loss) 으로 교체. 기존 investment_loss 값은 하위호환으로 유지하되 선택 UI에는 더 이상 노출하지 않고, 과거 저장 건은 읽기 전용 화면에서 계속 "투자손실"로 표시
- "최근 6개월 내 채무액" 필드 신규 추가, 기존 3개월/1년/담보부채무 필드와 함께 "채무내역" 카드 내부로 이동(간편·상세 입력 모드 및 결과화면 채무 상세 모달에서 공통 노출)
- 상세모드 채무 항목의 대출일·만기일·금액·금리 누락 시 셀 단위로 빨간 테두리 표시 및 안내 모달 추가
- 예상 변제 계획: 월 변제액이 0원(가용소득 사실상 없음)이면 "산정 불가"/"-"/"-"로 표시하고 타임라인·예상 면책/잔여 채무 박스는 숨김
- 목록 조회 응답의 totalDebt/disposableIncome이 null로 내려오는 경우를 방어해 목록 페이지 런타임 크래시(Cannot read properties of undefined (reading 'toLocaleString')) 수정
- 결과화면 "자세히 보기"/"제도안내" 버튼에 아이콘 추가 및 위치·스타일 정리