### PR TITLE
fix: 상담 내용 기록 메모에 시간 표시 및 한국 시간 기준 보정

### DIFF
--- a/src/components/customers/detail/ConsultationPanel.tsx
+++ b/src/components/customers/detail/ConsultationPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { formatDetailDate } from "./utils";
+import { formatConsultationNoteDateTime } from "./utils";
 import { CustomerCategoryHistoryItem, CustomerDetail } from "@/types/customers";
 import { getBadgeStyle } from "@/utils/categoryBadge";
 import { useMyMember } from "@/hooks/useMyMember";
@@ -381,7 +381,7 @@ export default function ConsultationPanel({
                       </span>
                       <div className="text-neutral-60 dark:text-neutral-60 flex gap-x-3 items-center justify-end">
                         <span className="text-right">
-                          {formatDetailDate(noteItem.createdAt)}
+                          {formatConsultationNoteDateTime(noteItem.createdAt)}
                         </span>
                         <button
                           className="cursor-pointer w-5 h-5 grid place-items-center rounded-full bg-black dark:bg-neutral-80 text-white dark:text-neutral-0"

--- a/src/components/customers/detail/ConsultationTab.tsx
+++ b/src/components/customers/detail/ConsultationTab.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { formatDetailDate } from "./utils";
+import { formatConsultationNoteDateTime } from "./utils";
 import { CustomerCategoryHistoryItem, CustomerDetail } from "@/types/customers";
 import { getBadgeStyle } from "@/utils/categoryBadge";
 import { useMyMember } from "@/hooks/useMyMember";
@@ -239,7 +239,7 @@ export default function ConsultationTab({
                     </span>
                     <div className="text-neutral-60 dark:text-neutral-60 flex gap-x-3 items-center justify-end">
                       <span className="text-right">
-                        {formatDetailDate(noteItem.createdAt)}
+                        {formatConsultationNoteDateTime(noteItem.createdAt)}
                       </span>
                       <button
                         className="cursor-pointer w-5 h-5 grid place-items-center rounded-full bg-black dark:bg-neutral-80 text-white dark:text-neutral-0"

--- a/src/components/customers/detail/utils.ts
+++ b/src/components/customers/detail/utils.ts
@@ -12,5 +12,30 @@ export function formatDetailDate(dt: string) {
   }
 }
 
+// 상담 내용 기록(메모) 타임스탬프: 날짜 + 시간을 항상 한국 시간(KST) 기준으로 표시
+export function formatConsultationNoteDateTime(dt: string) {
+  try {
+    const d = new Date(dt);
+    const parts = new Intl.DateTimeFormat("ko-KR", {
+      timeZone: "Asia/Seoul",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }).formatToParts(d);
+    const get = (type: string) => parts.find((part) => part.type === type)?.value ?? "";
+    const y = get("year");
+    const m = get("month");
+    const da = get("day");
+    const hh = get("hour") === "24" ? "00" : get("hour");
+    const mm = get("minute");
+    return `${y}. ${m}. ${da} ${hh}:${mm}`;
+  } catch {
+    return dt;
+  }
+}
+
 
 


### PR DESCRIPTION
- formatDetailDate는 날짜만 표시하고 시간이 누락되어 있었음
- 상담 메모 타임스탬프 전용 formatConsultationNoteDateTime 추가, Asia/Seoul 타임존으로 항상 KST 기준 표시