### PR TITLE
feat: 채무현황 채권자 수 구간 선택 복원 및 월 가용소득 음수 강조색 제거

### DIFF
--- a/src/components/debt-relief/form/Step3Debts.tsx
+++ b/src/components/debt-relief/form/Step3Debts.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import {
+  CREDITOR_COUNT_OPTIONS,
   DEBT_CAUSE_OPTIONS,
   type DiagnosisDerivedValues,
   type DiagnosisFormState,
 } from "@/types/debtRelief";
 import { FormField } from "./FormControls";
-import { PillMultiSelect } from "./PillSelect";
+import { PillMultiSelect, PillSelect } from "./PillSelect";
 import { FormToggleRow } from "./FormToggle";
 import { getOverLimitDebtFields } from "./validateDiagnosisForm";
 import DebtHistoryCard from "./DebtHistoryCard";
@@ -49,9 +50,22 @@ export default function Step3Debts({
       {/* 카드 바깥 공통 영역 — 채무 종류별 잔액과 무관하게 입력 방식 상관없이 항상 필요한 항목.
           「채무발생 원인」은 샘플사이트 기준 두 모드가 공유하는 필드라 카드 밖에 둔다. */}
       <div className="flex flex-col gap-5">
-        {/* 2026-08-04: 채권자 수는 화면에 노출하지 않는다 — 간편모드는 채무종류 배지 개수,
-            상세모드는 채무 항목 테이블 행 개수를 분석 제출 시점(services/debtRelief.ts의
-            toAnalysisFormInput)에 내부적으로 계산해서 보낼 뿐, 상담사가 확인/수정할 UI는 두지 않는다. */}
+        {/* 2026-08-07: 채권자 수(간편모드 전용)를 상담사가 직접 고르는 구간 선택으로 되돌림 —
+            채무종류 배지 개수로 자동 계산하면 실제 채권사 수와 크게 어긋나는 경우가 많았다.
+            상세모드는 채무 항목 테이블 행 개수를 그대로 쓰므로 노출하지 않는다. */}
+        {form.debtInputMode !== "detailed" && (
+          <FormField
+            label="채권자 수"
+            required
+            filled={form.creditorCount !== null}
+          >
+            <PillSelect
+              options={CREDITOR_COUNT_OPTIONS}
+              value={form.creditorCount}
+              onChange={(value) => update("creditorCount", value)}
+            />
+          </FormField>
+        )}
 
         <FormField label="체납이력">
           <FormToggleRow

--- a/src/components/debt-relief/form/Step4IncomeExpense.tsx
+++ b/src/components/debt-relief/form/Step4IncomeExpense.tsx
@@ -122,11 +122,7 @@ export default function Step4IncomeExpense({ form, update, derived }: Props) {
                 월 가용 소득
               </span>
               <span className="flex items-end gap-1">
-                <span
-                  className={`font-montserrat font-bold text-[20px] leading-5 tracking-[-0.03em] ${
-                    availableNegative ? "text-danger-40" : "text-neutral-90"
-                  }`}
-                >
+                <span className="font-montserrat font-bold text-[20px] leading-5 tracking-[-0.03em] text-neutral-90">
                   {availableNegative ? "-" : availableSign}
                   {availableAmount}
                 </span>

--- a/src/components/debt-relief/form/validateDiagnosisForm.ts
+++ b/src/components/debt-relief/form/validateDiagnosisForm.ts
@@ -71,6 +71,11 @@ export function getMissingRequiredFieldLabels(form: DiagnosisFormState): string[
   if (form.dependents === null) missing.push("부양가족");
   if (form.spouseIncome === null) missing.push("배우자 소득");
   missing.push(...getMissingDebtFieldLabels(form));
+  // 채권자 수(간편모드 전용)는 DebtHistoryCard 밖(Step3Debts)에서 입력받는 필드라 채무발생
+  // 원인과 같은 방식으로 여기서 별도 검사한다 — getMissingDebtFieldLabels에 넣으면 이 함수를
+  // 공유하는 결과화면 「채무 상세」 모달(DebtDetailModal, creditorCount 입력 UI 없음)까지
+  // 막혀버린다.
+  if (form.debtInputMode !== "detailed" && !form.creditorCount) missing.push("채권자 수");
   if (form.debtCauses.length === 0) missing.push("채무발생 원인");
   return missing;
 }
@@ -94,6 +99,7 @@ export function getMissingRequiredFieldLabelsForStep(
       return [];
     case "debts": {
       const missing = getMissingDebtFieldLabels(form);
+      if (form.debtInputMode !== "detailed" && !form.creditorCount) missing.push("채권자 수");
       if (form.debtCauses.length === 0) missing.push("채무발생 원인");
       return missing;
     }

--- a/src/services/debtRelief.ts
+++ b/src/services/debtRelief.ts
@@ -1,6 +1,7 @@
 import type {
   ConditionItem,
   CreateDiagnosisResult,
+  CreditorCountRange,
   DebtComposition,
   DebtType,
   DependentCount,
@@ -27,6 +28,7 @@ import type {
 } from "@/types/debtRelief";
 import {
   AGE_GROUP_OPTIONS,
+  CREDITOR_COUNT_TO_NUMBER,
   EMPLOYMENT_TYPE_OPTIONS,
   RECOMMENDED_PROCEDURE_LABEL,
   REGION_OPTIONS,
@@ -305,6 +307,22 @@ function optionLabel<T extends string>(options: { value: T; label: string }[], v
   return options.find((option) => option.value === value)?.label ?? "";
 }
 
+// 채권자 수는 구간 대표값(number)만 API에 남아 정확한 구간을 복원할 수 없을 수 있다
+// (예: 서버가 5~7 사이 값을 돌려주면 어느 구간에도 정확히 맞지 않는다). 자체 생성 분석은
+// 항상 CREDITOR_COUNT_TO_NUMBER의 대표값 중 하나로 보내므로 실질적으로는 발생하지 않지만,
+// 방어적으로 가장 가까운 구간으로 근사한다.
+const CREDITOR_COUNT_RANGES: { range: CreditorCountRange; representative: number }[] = (
+  Object.entries(CREDITOR_COUNT_TO_NUMBER) as [CreditorCountRange, number][]
+).map(([range, representative]) => ({ range, representative }));
+
+function creditorCountFromNumber(value: number): CreditorCountRange {
+  const exact = CREDITOR_COUNT_RANGES.find((entry) => entry.representative === value);
+  if (exact) return exact.range;
+  return CREDITOR_COUNT_RANGES.reduce((closest, entry) =>
+    Math.abs(entry.representative - value) < Math.abs(closest.representative - value) ? entry : closest
+  ).range;
+}
+
 // optionLabel의 역함수. 서버가 우리가 보낸 라벨을 그대로 echo한다는 전제(2026-07-14 기준
 // 확인됨) 하에 라벨 → 코드로 되돌린다. 못 찾으면 null(폼에서 미선택 상태로 취급).
 function optionValueFromLabel<T extends string>(
@@ -384,9 +402,13 @@ function toAnalysisFormInput(form: DiagnosisFormState): AnalysisFormInput {
     guarantorNote: form.guarantorDetail || undefined,
     hasActiveLawsuit: form.hasOngoingLitigation,
     lawsuitNote: form.litigationDetail || undefined,
-    // 채권자 수는 화면에 입력 UI가 없다 — 간편모드는 선택된 채무종류 배지 개수, 상세모드는
-    // 채무 항목 테이블 행 개수를 제출 시점에 여기서만 계산해서 보낸다.
-    creditorCount: isDetailed ? form.debts.length : form.debtTypes.length,
+    // 간편모드는 상담사가 직접 고른 구간의 대표값을, 상세모드는 채무 항목 테이블 행 개수를
+    // 그대로 보낸다(상세모드는 항목별로 실제 입력하므로 배지 선택이 필요 없다).
+    creditorCount: isDetailed
+      ? form.debts.length
+      : form.creditorCount
+        ? CREDITOR_COUNT_TO_NUMBER[form.creditorCount]
+        : undefined,
     hasTaxArrears: form.hasTaxArrears,
     hasRecentAssetDisposal: form.hasRecentAssetDisposal,
     isOperatingBusiness: form.isOperatingBusiness,
@@ -458,6 +480,7 @@ export function fromAnalysisFormInput(input: AnalysisInputData): DiagnosisFormSt
     // 서버는 모드와 무관하게 항상 숫자로 내려준다. 구 데이터(버킷 enum으로 저장된 건)에서
     // 값이 비어 올 가능성에 대비해 0으로 폴백한다.
     overdueMonths: input.overdueMonths ?? 0,
+    creditorCount: input.creditorCount != null ? creditorCountFromNumber(input.creditorCount) : null,
     debtCauses: input.debtCauses.map((cause) => DEBT_CAUSE_FROM_ANALYSIS[cause]),
     hasTaxArrears: input.hasTaxArrears ?? false,
     securedDebt: input.collateralDebt ?? 0,

--- a/src/types/debtRelief.ts
+++ b/src/types/debtRelief.ts
@@ -463,11 +463,25 @@ export const DEBT_CAUSE_OPTIONS: PillOption<DebtCause>[] = [
   { value: "other", label: DEBT_CAUSE_LABELS.other },
 ];
 
-// 2026-08-04: 채권자 수는 더 이상 사용자가 직접 고르거나 화면에 노출하지 않는다.
-// 간편모드는 선택된 채무종류 배지 개수, 상세모드는 채무 항목 테이블의 행 개수를 그대로
-// 채권자 수로 써서 분석 제출 시점에만 계산해 보낸다(services/debtRelief.ts의
-// toAnalysisFormInput 참고). 두 모드 모두 이미 "채무종류 1개 이상"/"채무 항목 1개 이상"을
-// 필수값으로 검증하므로 채권자 수가 0이 되는 경우는 존재하지 않아 별도 필수값 검사도 두지 않는다.
+// 2026-08-07 피드백: 간편모드의 채권자 수를 다시 상담사가 직접 고르는 구간 선택으로 되돌린다 —
+// 채무종류 배지 개수(최대 5개)를 그대로 쓰면 실제 채권사 수와 크게 어긋나는 경우가 많았기 때문.
+// API creditorCount는 여전히 number라 대표값으로 매핑해 보낸다(services/debtRelief.ts의
+// toAnalysisFormInput/creditorCountFromNumber 참고). 상세모드는 채무 항목 테이블 행 개수를
+// 그대로 쓰는 자동 계산을 유지 — 항목별로 실제 입력하니 배지 선택 대비 부정확할 이유가 없다.
+/** 채권자 수 구간(간편모드 전용) — API creditorCount(number)로 대표값 매핑 */
+export type CreditorCountRange = "1_2" | "3_5" | "6_10" | "over_10";
+export const CREDITOR_COUNT_OPTIONS: PillOption<CreditorCountRange>[] = [
+  { value: "1_2", label: "1~2곳" },
+  { value: "3_5", label: "3~5곳" },
+  { value: "6_10", label: "6~10곳" },
+  { value: "over_10", label: "10곳 이상" },
+];
+export const CREDITOR_COUNT_TO_NUMBER: Record<CreditorCountRange, number> = {
+  "1_2": 2,
+  "3_5": 4,
+  "6_10": 8,
+  over_10: 12,
+};
 
 // ── 4. 소득/지출 ─────────────────────────────────────────────
 // 2026-08-07 스펙: 구간 선택형(MonthlyIncomeRange) 폐지, 만원 단위 실수령액 직접 입력으로 변경.
@@ -565,6 +579,9 @@ export type DiagnosisFormState = {
   /** 연체 개월 수. 간편모드에서만 입력받고(필수), 상세모드는 서버가 debts에서 자동 계산한다.
    * null은 "미입력"이고 0은 "연체 없음"이라는 유효한 입력이다 — 숫자 falsy로 판정하면 안 된다 */
   overdueMonths: number | null;
+  /** 채권자 수 구간. 간편모드에서만 입력받고(필수) API 대표값(number)으로 매핑해 보낸다.
+   * 상세모드는 채무 항목 테이블 행 개수를 그대로 써서 이 값을 무시한다. */
+  creditorCount: CreditorCountRange | null;
   debtCauses: DebtCause[];
   hasTaxArrears: boolean; // 세금/4대보험 체납 여부
   // 2026-07-24 피드백 추가 항목. API collateralDebt/debtIncurredLast3Months/debtIncurredLast1Year에
@@ -624,6 +641,7 @@ export function createEmptyDiagnosisForm(): DiagnosisFormState {
     debtAmounts: {},
     debts: [],
     overdueMonths: null,
+    creditorCount: null,
     debtCauses: [],
     hasTaxArrears: false,
     securedDebt: 0,


### PR DESCRIPTION
- 2026-08-04에 제거됐던 채권자 수(1~2/3~5/6~10/10곳 이상) 뱃지 선택을 간편모드에 한해 복원 — 채무종류 배지 개수 자동계산이 실제 채권사 수와 크게 어긋나는 경우가 많아 상담사가 직접 고르도록 되돌림. 상세모드는 채무 항목 행 개수 자동계산 유지. DebtHistoryCard 밖(Step3Debts)에 배치해 결과화면 「채무 상세」 수정 모달(해당 입력 UI 없음)의 필수값 검증에는 영향 없게 분리.
- 소득/지출 스텝의 월 가용소득 표시에서 음수일 때 danger 색상을 빼고 항상 기본 텍스트 색으로 통일.