### PR TITLE
fix: 분석 신규/수정 폼 자산·소득·채무 스텝 개선

### DIFF
--- a/src/components/debt-relief/form/DebtHistoryCard.tsx
+++ b/src/components/debt-relief/form/DebtHistoryCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  CREDITOR_COUNT_OPTIONS,
   DEBT_AMOUNT_LABELS,
   DEBT_TYPE_OPTIONS,
   createEmptyDebtItem,
@@ -8,7 +9,7 @@ import {
   type DiagnosisFormState,
 } from "@/types/debtRelief";
 import { FormField, ManwonInput, MonthsInput } from "./FormControls";
-import { PillMultiSelect } from "./PillSelect";
+import { PillMultiSelect, PillSelect } from "./PillSelect";
 import DebtItemsTable from "./DebtItemsTable";
 import type { OverLimitDebtField } from "./validateDiagnosisForm";
 
@@ -213,6 +214,16 @@ export default function DebtHistoryCard({
               <MonthsInput
                 value={form.overdueMonths}
                 onChange={(value) => update("overdueMonths", value)}
+              />
+            </FormField>
+
+            {/* 2026-08-07: 채무내역 카드 바깥(Step3Debts)에 있던 걸 카드 안으로 이동.
+                상세모드는 채무 항목 테이블 행 개수를 그대로 쓰므로 노출하지 않는다. */}
+            <FormField label="채권자 수" required filled={form.creditorCount !== null}>
+              <PillSelect
+                options={CREDITOR_COUNT_OPTIONS}
+                value={form.creditorCount}
+                onChange={(value) => update("creditorCount", value)}
               />
             </FormField>
           </div>

--- a/src/components/debt-relief/form/Step2Assets.tsx
+++ b/src/components/debt-relief/form/Step2Assets.tsx
@@ -45,6 +45,7 @@ export default function Step2Assets({ form, update }: Props) {
     }
 
     update("realEstateTypes", selectedTypes);
+    update("realEstateStatusConfirmed", true);
 
     if (selectedTypes.length === 0) {
       update("realEstateAmounts", {});
@@ -72,7 +73,8 @@ export default function Step2Assets({ form, update }: Props) {
         <FormField
           label="부동산 보유 여부"
           hint="(중복선택 가능)"
-          filled={form.realEstateTypes.length > 0}
+          required
+          filled={form.realEstateStatusConfirmed}
         >
           <PillMultiSelect
             options={REAL_ESTATE_SELECT_OPTIONS}
@@ -100,6 +102,7 @@ export default function Step2Assets({ form, update }: Props) {
 
         <FormField
           label="금융 자산 (예·적금 + 주식 등)"
+          required
           filled={form.financialAssetValue !== null}
         >
           <ManwonQuickInput
@@ -109,7 +112,7 @@ export default function Step2Assets({ form, update }: Props) {
           />
         </FormField>
 
-        <FormField label="차량 보유" filled={form.vehicleValue !== null}>
+        <FormField label="차량 보유" required filled={form.vehicleValue !== null}>
           <ManwonQuickInput
             value={form.vehicleValue}
             onChange={(value) => update("vehicleValue", value)}

--- a/src/components/debt-relief/form/Step3Debts.tsx
+++ b/src/components/debt-relief/form/Step3Debts.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import {
-  CREDITOR_COUNT_OPTIONS,
   DEBT_CAUSE_OPTIONS,
   type DiagnosisDerivedValues,
   type DiagnosisFormState,
 } from "@/types/debtRelief";
 import { FormField } from "./FormControls";
-import { PillMultiSelect, PillSelect } from "./PillSelect";
+import { PillMultiSelect } from "./PillSelect";
 import { FormToggleRow } from "./FormToggle";
 import { getOverLimitDebtFields } from "./validateDiagnosisForm";
 import DebtHistoryCard from "./DebtHistoryCard";
@@ -48,25 +47,9 @@ export default function Step3Debts({
       />
 
       {/* 카드 바깥 공통 영역 — 채무 종류별 잔액과 무관하게 입력 방식 상관없이 항상 필요한 항목.
-          「채무발생 원인」은 샘플사이트 기준 두 모드가 공유하는 필드라 카드 밖에 둔다. */}
+          「채무발생 원인」은 샘플사이트 기준 두 모드가 공유하는 필드라 카드 밖에 둔다.
+          「채권자 수」는 2026-08-07부터 DebtHistoryCard(채무내역) 안으로 이동했다. */}
       <div className="flex flex-col gap-5">
-        {/* 2026-08-07: 채권자 수(간편모드 전용)를 상담사가 직접 고르는 구간 선택으로 되돌림 —
-            채무종류 배지 개수로 자동 계산하면 실제 채권사 수와 크게 어긋나는 경우가 많았다.
-            상세모드는 채무 항목 테이블 행 개수를 그대로 쓰므로 노출하지 않는다. */}
-        {form.debtInputMode !== "detailed" && (
-          <FormField
-            label="채권자 수"
-            required
-            filled={form.creditorCount !== null}
-          >
-            <PillSelect
-              options={CREDITOR_COUNT_OPTIONS}
-              value={form.creditorCount}
-              onChange={(value) => update("creditorCount", value)}
-            />
-          </FormField>
-        )}
-
         <FormField label="체납이력">
           <FormToggleRow
             label="세금/4대보험 체납이력 있음"

--- a/src/components/debt-relief/form/Step4IncomeExpense.tsx
+++ b/src/components/debt-relief/form/Step4IncomeExpense.tsx
@@ -22,7 +22,6 @@ function signedManwon(value: number): string {
 }
 
 export default function Step4IncomeExpense({ form, update, derived }: Props) {
-  const availableSign = derived.monthlyAvailableIncomeManwon >= 0 ? "+" : "";
   const availableAmount = Math.abs(derived.monthlyAvailableIncomeManwon).toLocaleString("ko-KR");
   const availableNegative = derived.monthlyAvailableIncomeManwon < 0;
 
@@ -74,7 +73,10 @@ export default function Step4IncomeExpense({ form, update, derived }: Props) {
           />
         </FormField>
 
-        {/* 월 가용 소득 계산 — Figma: 보더 박스, 1·2행 투명 / 3행만 Light-10, 행 h-40 */}
+        {/* 월 가용 소득 계산 — Figma: 보더 박스, 1·2행 투명 / 3행만 Light-10, 행 h-40.
+            부양가족을 아직 선택하지 않았으면 법정 생계비를 0으로 둔다 — 가구원 1인 기준
+            실제값(-154만원)을 임의로 가정해 보여주면 아무것도 고르지 않았는데 마이너스가
+            나오는 것처럼 보인다. "없음"을 명시적으로 선택하면 그때부터 실제 값을 반영한다. */}
         <div>
           <h3 className="text-[16px] font-semibold tracking-[0.2px] text-foreground mb-3">
             월 가용 소득 (법원 인정 기준)
@@ -96,7 +98,8 @@ export default function Step4IncomeExpense({ form, update, derived }: Props) {
                 </span>
               </span>
               <span className="shrink-0 text-[14px] font-semibold leading-4 tracking-[0.2px] text-neutral-60">
-                -{derived.minimumLivingCostManwon.toLocaleString("ko-KR")}만원
+                {derived.minimumLivingCostManwon > 0 ? "-" : ""}
+                {derived.minimumLivingCostManwon.toLocaleString("ko-KR")}만원
               </span>
             </div>
             <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 px-4 min-h-10 py-2 border-b border-neutral-30">
@@ -123,7 +126,7 @@ export default function Step4IncomeExpense({ form, update, derived }: Props) {
               </span>
               <span className="flex items-end gap-1">
                 <span className="font-montserrat font-bold text-[20px] leading-5 tracking-[-0.03em] text-neutral-90">
-                  {availableNegative ? "-" : availableSign}
+                  {availableNegative ? "-" : ""}
                   {availableAmount}
                 </span>
                 <span className="text-[13px] font-semibold leading-4 text-neutral-60">만원</span>

--- a/src/components/debt-relief/form/useDiagnosisForm.ts
+++ b/src/components/debt-relief/form/useDiagnosisForm.ts
@@ -36,8 +36,12 @@ export function useDiagnosisForm() {
     // 법원 인정 기준 월 가용소득 = 월소득 − 가구원수별 법원 인정 최저생계비 − 추가 인정 고정지출
     // (서버 disposableIncome과 동일 공식 — 2026-08-07 스펙). 원 단위로 계산 후 만원으로 환산해
     // 중간 반올림 오차를 줄인다.
+    // 부양가족을 아직 선택하지 않았으면(null) 아무것도 확정되지 않은 상태이므로, 가구원 1인
+    // 기준값을 임의로 가정해 마이너스로 보여주지 않고 최저생계비를 0으로 둔다. "없음"을
+    // 명시적으로 선택하면(dependents="0") 그때부터 가구원 1인 기준 실제 값을 반영한다.
     const householdSize = resolveHouseholdSize(form.dependents);
-    const minimumLivingCostWon = resolveCourtMinimumLivingCostWon(householdSize);
+    const minimumLivingCostWon =
+      form.dependents === null ? 0 : resolveCourtMinimumLivingCostWon(householdSize);
     const minimumLivingCostManwon = wonToManwon(minimumLivingCostWon);
     const monthlyAvailableIncomeWon =
       manwonToWon(form.monthlyIncome ?? 0) -

--- a/src/components/debt-relief/form/validateDiagnosisForm.ts
+++ b/src/components/debt-relief/form/validateDiagnosisForm.ts
@@ -70,11 +70,13 @@ export function getMissingRequiredFieldLabels(form: DiagnosisFormState): string[
   if (!form.housingType) missing.push("주거 형태");
   if (form.dependents === null) missing.push("부양가족");
   if (form.spouseIncome === null) missing.push("배우자 소득");
+  if (!form.realEstateStatusConfirmed) missing.push("부동산 보유 여부");
+  if (form.financialAssetValue === null) missing.push("금융 자산");
+  if (form.vehicleValue === null) missing.push("차량 보유");
   missing.push(...getMissingDebtFieldLabels(form));
-  // 채권자 수(간편모드 전용)는 DebtHistoryCard 밖(Step3Debts)에서 입력받는 필드라 채무발생
-  // 원인과 같은 방식으로 여기서 별도 검사한다 — getMissingDebtFieldLabels에 넣으면 이 함수를
-  // 공유하는 결과화면 「채무 상세」 모달(DebtDetailModal, creditorCount 입력 UI 없음)까지
-  // 막혀버린다.
+  // 채권자 수(간편모드 전용)는 채무발생 원인과 같은 방식으로 여기서 별도 검사한다 —
+  // getMissingDebtFieldLabels에 넣으면 이 함수를 공유하는 결과화면 「채무 상세」 모달
+  // (DebtDetailModal, creditorCount 입력 UI 없음)까지 막혀버린다.
   if (form.debtInputMode !== "detailed" && !form.creditorCount) missing.push("채권자 수");
   if (form.debtCauses.length === 0) missing.push("채무발생 원인");
   return missing;
@@ -94,9 +96,14 @@ export function getMissingRequiredFieldLabelsForStep(
       if (!form.region) missing.push("거주 지역");
       return missing;
     }
-    case "assets":
-      // 금융 자산/차량 가액은 null(미선택)·0(미보유 명시)을 구분한다. 스텝 필수 검사는 없음.
-      return [];
+    case "assets": {
+      const missing: string[] = [];
+      if (!form.realEstateStatusConfirmed) missing.push("부동산 보유 여부");
+      // 금융 자산/차량 가액은 null(미선택)·0(미보유 명시)을 구분해 null만 미입력으로 판정한다.
+      if (form.financialAssetValue === null) missing.push("금융 자산");
+      if (form.vehicleValue === null) missing.push("차량 보유");
+      return missing;
+    }
     case "debts": {
       const missing = getMissingDebtFieldLabels(form);
       if (form.debtInputMode !== "detailed" && !form.creditorCount) missing.push("채권자 수");

--- a/src/services/debtRelief.ts
+++ b/src/services/debtRelief.ts
@@ -468,6 +468,8 @@ export function fromAnalysisFormInput(input: AnalysisInputData): DiagnosisFormSt
     dependents: DEPENDENTS_FROM_ANALYSIS[input.dependents] ?? null,
     spouseIncome: input.hasSpouseIncome,
     realEstateTypes,
+    // 기존에 저장된 분석은 이 필드가 생기기 전에 제출된 것이므로 이미 답변된 것으로 간주한다.
+    realEstateStatusConfirmed: true,
     realEstateAmounts,
     financialAssetValue: input.financialAssetValue ?? 0,
     vehicleValue: input.vehicleValue ?? 0,

--- a/src/types/debtRelief.ts
+++ b/src/types/debtRelief.ts
@@ -562,6 +562,9 @@ export type DiagnosisFormState = {
 
   // 2. 자산현황
   realEstateTypes: RealEstateType[]; // 중복 보유 가능
+  /** "없음" 선택도 realEstateTypes=[]로 저장되어 미선택과 구분이 안 되므로, 필수 검증용으로
+   * 사용자가 이 필드를 한 번이라도 명시적으로 조작했는지 별도로 추적한다. */
+  realEstateStatusConfirmed: boolean;
   realEstateAmounts: Partial<Record<RealEstateType, number>>; // 만원, 선택된 종류만
   /** 만원 단위(예·적금+주식 등 합계). null=미선택, 0=미보유(명시) */
   financialAssetValue: number | null;
@@ -632,6 +635,7 @@ export function createEmptyDiagnosisForm(): DiagnosisFormState {
     spouseIncome: null,
     isOperatingBusiness: false,
     realEstateTypes: [],
+    realEstateStatusConfirmed: false,
     realEstateAmounts: {},
     financialAssetValue: null,
     vehicleValue: null,


### PR DESCRIPTION
- 자산현황: 부동산 보유 여부·금융 자산·차량 보유 필수 입력화 (부동산은 "없음"과 미선택 구분을 위해 realEstateStatusConfirmed 플래그 추가)
- 소득/지출: 부양가족 미선택 시 법정 생계비를 0으로 계산해 마이너스 금액이 먼저 노출되지 않도록 수정, 월 가용 소득 양수 표시 시 + 부호 제거
- 채무현황: 채권자 수 필드를 채무내역(DebtHistoryCard) 카드 안으로 이동