### PR TITLE
fix: 채무현황 간편모드 전용 필드가 상세모드에도 노출되던 문제 수정

### DIFF
--- a/docs/DEBT_RELIEF_SIMPLE_ONLY_FIELDS_TASKS.md
+++ b/docs/DEBT_RELIEF_SIMPLE_ONLY_FIELDS_TASKS.md
@@ -1,0 +1,85 @@
+# 채무현황 "간편 전용" 필드가 상세모드에도 노출되는 문제 — Task
+
+## 0. 배경 (2026-08-07)
+
+`/debt-relief/new?step=3`과 수정 페이지의 「채무내역」 카드는 간편/상세 두 입력 모드를 토글로
+구분해서 렌더링한다. 그런데 다음 4개 필드는 원래 **간편모드에서만 기재하는 값**인데도 현재
+코드에서는 상세모드에서도 그대로 노출·전송되고 있다.
+
+- 최근 3개월 내 채무액 (`recentDebtWithin3Months`)
+- 최근 6개월 내 채무액 (`recentDebtWithin6Months`)
+- 최근 1년 내 채무액 (`recentDebtWithin1Year`)
+- 담보부채무 (`securedDebt`)
+
+기존에 상세모드로 저장된 데이터는 손대지 않는다(마이그레이션 없음) — 표시만 모드 기준으로
+정리하고, 과거에 값이 들어간 레코드는 그냥 더 이상 보여주지 않는 방향으로 처리.
+
+**실 시행 시점:** §2 코드 수정은 2026-08-07에 완료(`tsc --noEmit`, `eslint` 통과). 3000번
+포트가 다른 작업으로 사용 중이라 브라우저 수동 검증만 사용자가 별도로 지시할 때 진행한다.
+
+## 1. 확인된 현재 동작 (조사 완료)
+
+### 1-1. 폼 UI — `src/components/debt-relief/form/DebtHistoryCard.tsx`
+- 153번 줄 `form.debtInputMode === "detailed" ? <DebtItemsTable /> : (간편 전용 필드들)` 분기는
+  채무종류/채무종류별 잔액/채권자 수만 감싸고 있음.
+- 232~265번 줄(구분선 + 4개 필드 grid)은 이 분기 **바깥**에 있어 상세모드에서도 그대로 렌더링됨.
+- 232번 줄 주석 "입력 방식(간편/상세)과 상관없이 항상 필요한 항목"이 애초에 잘못된 전제.
+
+### 1-2. 초과검증 — `src/components/debt-relief/form/validateDiagnosisForm.ts`
+- `isRecentAndSecuredDebtOverTotal`(130~140번 줄)이 이 4개 필드 합이 총 채무 합계를 넘는지
+  모드 구분 없이 검사. `getOverLimitDebtFields`도 동일하게 모드 무관.
+- 상세모드에서 이 필드들이 숨겨지면 이 초과검증 자체가 상세모드에선 의미 없어짐(그리고 폼에
+  남아있는 과거 간편모드 값 때문에 상세모드에서 갑자기 초과 판정이 뜨는 오탐 가능성도 있음).
+
+### 1-3. 제출 — `src/services/debtRelief.ts`
+- `toAnalysisFormInput`(391~394번 줄): `collateralDebt`/`debtIncurredLast3Months`/
+  `debtIncurredLast6Months`/`debtIncurredLast1Year`를 `isDetailed` 분기 없이 무조건 `form.securedDebt`
+  등 폼 값 그대로 전송. 바로 위(384번 줄)에서 `debts` vs `debtBreakdown`은 모드별로 분기하면서
+  이 4개만 놓친 것으로 보임.
+- `updateDiagnosisDebts`(1057~1080번 줄, PATCH `/v1/analysis/{id}/debts`)도 동일 패턴
+  (1073~1076번 줄) — 결과화면 「채무 상세」 모달에서 저장할 때도 같은 문제.
+
+  **단, `types/analysis.ts`의 `AnalysisFormInput`/`UpdateAnalysisDebtsInput`에서
+  `collateralDebt`/`debtIncurredLast3Months`/`debtIncurredLast6Months`/`debtIncurredLast1Year`는
+  `debtBreakdown?`/`debts?`와 달리 **optional이 아닌 필수 `number`** 다(171~195번, 246~256번 줄).
+  즉 백엔드 계약상 이 필드들은 모드와 무관하게 항상 값을 요구한다 — 그래서 상세모드에서
+  "아예 안 보낸다"는 선택지는 없고, **UI에서는 숨기되 제출 시 0으로 고정해서 보내는** 방식이
+  맞다(값은 폼 상태에 남겨둬도 되지만 전송 직전에 모드에 따라 0으로 덮어써야 함).**
+
+### 1-4. 결과화면 표시 — `src/components/debt-relief/result/DiagnosisCustomerInfoModal.tsx`
+- `debtRightRows`(280~287번 줄)가 `input.debtInputMode`를 전혀 참조하지 않고 4개 행을 무조건 표시.
+- 이 컴포넌트는 `debtInputMode`/`debts`를 아예 안 쓴다(grep 결과 0건) — 참고로 `debtLeftRows`의
+  채무종류/은행대출/카드론/캐피탈저축은행 breakdown도 상세모드 레코드에서는 `debtBreakdown`이
+  채워지지 않으므로 이미 별도로 깨져 있을 가능성이 있음. **이건 이번 요청 범위 밖**(사용자가
+  명시한 건 4개 필드뿐)이라 별도 이슈로만 남겨둔다 — 손대지 않음.
+
+### 1-5. 결과화면 「채무 상세」 모달 — `src/components/debt-relief/result/DebtDetailModal.tsx`
+- `DebtHistoryCard`를 그대로 재사용(211~218번 줄)하므로 1-1 수정이 반영되면 자동으로 같이 해결됨.
+- `computeTotalDebtManwon`(51~60번 줄)은 이미 모드 분기가 있어 손댈 필요 없음.
+
+### 1-6. sms `templates.ts`
+- 최초 grep 매치는 "최근 3개월 급여명세서"라는 무관한 문자열이었음 — 이 파일은 스코프 밖.
+
+## 2. 계획한 수정 (2026-08-07 완료)
+
+- [x] `DebtHistoryCard.tsx`: 4개 필드 grid를 `form.debtInputMode !== "detailed"`일 때만
+      렌더링하도록 조건부 처리(구분선 포함 `<>...</>`로 감쌈). 주석도 "간편모드 전용"으로 정정.
+- [x] `validateDiagnosisForm.ts`: `isRecentAndSecuredDebtOverTotal` 최상단에
+      `if (form.debtInputMode === "detailed") return false;` 가드 추가
+      (→ `getOverLimitDebtFields`도 자동으로 `[]`).
+- [x] `services/debtRelief.ts`:
+  - `toAnalysisFormInput`: 4개 필드를 `isDetailed ? 0 : form.xxx`로 분기.
+  - `updateDiagnosisDebts`: 동일 패턴으로 `isDetailed` 분기 추가(기존 `isDetailed` 변수 재사용).
+- [x] `DiagnosisCustomerInfoModal.tsx`: `debtRightRows`에서 4개 필드 행을
+      `input.debtInputMode === "detailed"`일 때 스프레드로 제외("연체기간"/"채무발생원인"만 유지).
+- [x] `types/debtRelief.ts` 590~595번 줄 주석에 "간편모드 전용 — 상세모드는 제출 시 0 고정" 명시.
+- [x] `npx tsc --noEmit` 통과 / `npx eslint`(변경 파일 5개) 통과.
+- [ ] 브라우저 수동 검증(간편↔상세 토글, 신규 생성/수정/결과화면 「채무 상세」 모달, 결과화면
+      고객정보 모달) — **3000번 포트 사용 가능해지면 사용자 지시 후 진행**.
+
+## 3. 스코프 밖으로 명시적으로 제외한 것
+
+- 기존에 상세모드로 저장된 분석 건에 이미 들어가 있는 4개 필드 값 — 마이그레이션하지 않음,
+  표시만 안 하게 됨.
+- `DiagnosisCustomerInfoModal.tsx`의 `debtLeftRows`(채무종류/은행대출/카드론/캐피탈저축은행
+  breakdown)가 상세모드 레코드에서 제대로 표시되는지 여부 — 별도 조사 필요, 이번 요청과는 무관.

--- a/src/components/debt-relief/form/DebtHistoryCard.tsx
+++ b/src/components/debt-relief/form/DebtHistoryCard.tsx
@@ -229,40 +229,45 @@ export default function DebtHistoryCard({
           </div>
         )}
 
-        {/* 채무 종류별 잔액과 무관하게 입력 방식(간편/상세)과 상관없이 항상 필요한 항목 —
-            2026-08-06: 기존에 카드 바깥에 있던 것을 「채무내역」 카드 안으로 이동. */}
-        <div role="separator" className="h-px bg-neutral-30" />
+        {/* 간편모드 전용 항목 — 최근 3/6개월·1년 내 채무액, 담보부채무는 상세모드(채무 항목
+            테이블)에서는 입력받지 않는다. 2026-08-06: 기존에 카드 바깥에 있던 것을
+            「채무내역」 카드 안으로 이동. */}
+        {form.debtInputMode !== "detailed" && (
+          <>
+            <div role="separator" className="h-px bg-neutral-30" />
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-7 gap-y-4 md:gap-y-5">
-          <FormField label="최근 3개월 내 채무액" filled={form.recentDebtWithin3Months > 0}>
-            <ManwonInput
-              value={form.recentDebtWithin3Months}
-              onChange={(value) => update("recentDebtWithin3Months", value)}
-              invalid={overLimitFields.includes("recentDebtWithin3Months")}
-            />
-          </FormField>
-          <FormField label="최근 6개월 내 채무액" filled={form.recentDebtWithin6Months > 0}>
-            <ManwonInput
-              value={form.recentDebtWithin6Months}
-              onChange={(value) => update("recentDebtWithin6Months", value)}
-              invalid={overLimitFields.includes("recentDebtWithin6Months")}
-            />
-          </FormField>
-          <FormField label="최근 1년 내 채무액" filled={form.recentDebtWithin1Year > 0}>
-            <ManwonInput
-              value={form.recentDebtWithin1Year}
-              onChange={(value) => update("recentDebtWithin1Year", value)}
-              invalid={overLimitFields.includes("recentDebtWithin1Year")}
-            />
-          </FormField>
-          <FormField label="담보부채무" filled={form.securedDebt > 0}>
-            <ManwonInput
-              value={form.securedDebt}
-              onChange={(value) => update("securedDebt", value)}
-              invalid={overLimitFields.includes("securedDebt")}
-            />
-          </FormField>
-        </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-x-7 gap-y-4 md:gap-y-5">
+              <FormField label="최근 3개월 내 채무액" filled={form.recentDebtWithin3Months > 0}>
+                <ManwonInput
+                  value={form.recentDebtWithin3Months}
+                  onChange={(value) => update("recentDebtWithin3Months", value)}
+                  invalid={overLimitFields.includes("recentDebtWithin3Months")}
+                />
+              </FormField>
+              <FormField label="최근 6개월 내 채무액" filled={form.recentDebtWithin6Months > 0}>
+                <ManwonInput
+                  value={form.recentDebtWithin6Months}
+                  onChange={(value) => update("recentDebtWithin6Months", value)}
+                  invalid={overLimitFields.includes("recentDebtWithin6Months")}
+                />
+              </FormField>
+              <FormField label="최근 1년 내 채무액" filled={form.recentDebtWithin1Year > 0}>
+                <ManwonInput
+                  value={form.recentDebtWithin1Year}
+                  onChange={(value) => update("recentDebtWithin1Year", value)}
+                  invalid={overLimitFields.includes("recentDebtWithin1Year")}
+                />
+              </FormField>
+              <FormField label="담보부채무" filled={form.securedDebt > 0}>
+                <ManwonInput
+                  value={form.securedDebt}
+                  onChange={(value) => update("securedDebt", value)}
+                  invalid={overLimitFields.includes("securedDebt")}
+                />
+              </FormField>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/debt-relief/form/validateDiagnosisForm.ts
+++ b/src/components/debt-relief/form/validateDiagnosisForm.ts
@@ -126,11 +126,14 @@ export function getMissingRequiredFieldLabelsForStep(
   }
 }
 
-/** 담보부채무·최근 3개월/6개월/1년 내 채무액 합이 총 채무 합계(채무종류별 금액 합)를 넘는지 검사 */
+/** 담보부채무·최근 3개월/6개월/1년 내 채무액 합이 총 채무 합계(채무종류별 금액 합)를 넘는지 검사.
+ * 이 4개 필드는 간편모드 전용이라 상세모드에서는 검사하지 않는다(폼에 남아있는 과거 간편모드
+ * 값 때문에 상세모드에서 오탐이 뜨는 걸 방지). */
 export function isRecentAndSecuredDebtOverTotal(
   form: DiagnosisFormState,
   totalDebtManwon: number
 ): boolean {
+  if (form.debtInputMode === "detailed") return false;
   const sum =
     form.securedDebt +
     form.recentDebtWithin3Months +

--- a/src/components/debt-relief/result/DiagnosisCustomerInfoModal.tsx
+++ b/src/components/debt-relief/result/DiagnosisCustomerInfoModal.tsx
@@ -277,11 +277,16 @@ function buildSections(input: AnalysisInputData) {
     { label: "총 채무합계", value: formatManwon(input.totalDebt), emphasize: true },
   ];
 
+  // 3/6개월·1년 내 채무액, 담보부채무는 간편모드 전용 필드라 상세모드 건에서는 표시하지 않는다.
   const debtRightRows: DisplayRow[] = [
-    { label: "3개월 내 채무액", value: formatManwon(input.debtIncurredLast3Months) },
-    { label: "6개월 내 채무액", value: formatManwon(input.debtIncurredLast6Months) },
-    { label: "1년 내 채무액", value: formatManwon(input.debtIncurredLast1Year) },
-    { label: "담보부채무", value: formatManwon(input.collateralDebt) },
+    ...(input.debtInputMode === "detailed"
+      ? []
+      : [
+          { label: "3개월 내 채무액", value: formatManwon(input.debtIncurredLast3Months) },
+          { label: "6개월 내 채무액", value: formatManwon(input.debtIncurredLast6Months) },
+          { label: "1년 내 채무액", value: formatManwon(input.debtIncurredLast1Year) },
+          { label: "담보부채무", value: formatManwon(input.collateralDebt) },
+        ]),
     { label: "연체기간", value: `${input.overdueMonths ?? 0}개월` },
     { label: "채무발생원인", value: debtCausesLabel(input.debtCauses ?? []) },
   ];

--- a/src/services/debtRelief.ts
+++ b/src/services/debtRelief.ts
@@ -388,10 +388,12 @@ function toAnalysisFormInput(form: DiagnosisFormState): AnalysisFormInput {
           debtBreakdown,
           overdueMonths: form.overdueMonths ?? 0,
         }),
-    collateralDebt: form.securedDebt,
-    debtIncurredLast3Months: form.recentDebtWithin3Months,
-    debtIncurredLast6Months: form.recentDebtWithin6Months,
-    debtIncurredLast1Year: form.recentDebtWithin1Year,
+    // 간편모드 전용 필드 — API는 모드와 무관하게 항상 값을 요구하므로(optional 아님) 상세모드에서는
+    // 폼에 남아있는 과거 간편모드 값을 보내지 않고 0으로 고정한다.
+    collateralDebt: isDetailed ? 0 : form.securedDebt,
+    debtIncurredLast3Months: isDetailed ? 0 : form.recentDebtWithin3Months,
+    debtIncurredLast6Months: isDetailed ? 0 : form.recentDebtWithin6Months,
+    debtIncurredLast1Year: isDetailed ? 0 : form.recentDebtWithin1Year,
     debtCauses: form.debtCauses.map((cause) => DEBT_CAUSE_TO_ANALYSIS[cause]),
     realEstateBreakdown,
     financialAssetValue: form.financialAssetValue ?? 0,
@@ -1070,10 +1072,11 @@ export const DebtReliefService = {
             debtBreakdown: buildDebtBreakdown(form),
             overdueMonths: form.overdueMonths ?? 0,
           }),
-      collateralDebt: form.securedDebt,
-      debtIncurredLast3Months: form.recentDebtWithin3Months,
-      debtIncurredLast6Months: form.recentDebtWithin6Months,
-      debtIncurredLast1Year: form.recentDebtWithin1Year,
+      // 간편모드 전용 필드 — toAnalysisFormInput과 동일하게 상세모드에서는 0으로 고정.
+      collateralDebt: isDetailed ? 0 : form.securedDebt,
+      debtIncurredLast3Months: isDetailed ? 0 : form.recentDebtWithin3Months,
+      debtIncurredLast6Months: isDetailed ? 0 : form.recentDebtWithin6Months,
+      debtIncurredLast1Year: isDetailed ? 0 : form.recentDebtWithin1Year,
       debtCauses: form.debtCauses.map((cause) => DEBT_CAUSE_TO_ANALYSIS[cause]),
       reanalyze,
     });

--- a/src/types/debtRelief.ts
+++ b/src/types/debtRelief.ts
@@ -588,7 +588,8 @@ export type DiagnosisFormState = {
   debtCauses: DebtCause[];
   hasTaxArrears: boolean; // 세금/4대보험 체납 여부
   // 2026-07-24 피드백 추가 항목. API collateralDebt/debtIncurredLast3Months/debtIncurredLast1Year에
-  // 대응(services/debtRelief.ts 참고).
+  // 대응(services/debtRelief.ts 참고). 간편모드 전용 — 상세모드에서는 입력받지 않고 제출 시 0으로
+  // 고정한다(API 스펙상 optional이 아니라 값 자체는 항상 보내야 함).
   securedDebt: number; // 담보부채무 (만원)
   recentDebtWithin3Months: number; // 최근 3개월 내 채무액 (만원)
   recentDebtWithin6Months: number; // 최근 6개월 내 채무액 (만원). 2026-08-06 스펙 추가


### PR DESCRIPTION
최근 3/6개월·1년 내 채무액, 담보부채무 4개 필드는 간편모드 전용인데
상세모드에서도 입력 UI가 노출되고 값이 그대로 API로 전송되고 있었다.
상세모드에서는 UI를 숨기고 제출 시 0으로 고정하며(API 스펙상 필수값이라
아예 생략은 불가), 결과화면 고객정보 모달과 초과검증도 모드에 맞게 정리.