### PR TITLE
fix: 채무 재분석 경고 보강, 월 가용소득 표시 통일, 부동산 보유 자동선택 버그 수정

### DIFF
--- a/src/components/debt-relief/form/Step2Assets.tsx
+++ b/src/components/debt-relief/form/Step2Assets.tsx
@@ -25,9 +25,15 @@ export default function Step2Assets({ form, update }: Props) {
     update("realEstateAmounts", { ...form.realEstateAmounts, [type]: value });
   };
 
-  // 빈 배열(=없음)일 때도 UI에서는 "없음"이 선택된 것처럼 보이게 한다.
+  // 빈 배열(=없음)이어도 아직 한 번도 선택하지 않은 상태(미확인)라면 "없음"을 미리 선택된
+  // 것처럼 보여주면 안 된다 — 실제로는 미확인(필수값 누락)인데 "없음"이 이미 검게 선택된
+  // 것처럼 보여서, 클릭해도 먼저 해제된 뒤 한 번 더 눌러야 체크되는 버그가 있었다.
   const realEstateSelectValue: RealEstateSelectValue[] =
-    form.realEstateTypes.length === 0 ? ["none"] : form.realEstateTypes;
+    form.realEstateTypes.length === 0
+      ? form.realEstateStatusConfirmed
+        ? ["none"]
+        : []
+      : form.realEstateTypes;
 
   const handleRealEstateChange = (next: RealEstateSelectValue[]) => {
     const wasNone = form.realEstateTypes.length === 0;

--- a/src/components/debt-relief/result/DebtApplyChoiceModal.tsx
+++ b/src/components/debt-relief/result/DebtApplyChoiceModal.tsx
@@ -76,7 +76,8 @@ export default function DebtApplyChoiceModal({
         </div>
 
         <p className="px-7 pb-6 text-[14px] leading-5 font-medium text-neutral-70">
-          다시 분석하면 추천 절차·변제 계획이 갱신되고, 값만 저장하면 채무 구성만 반영됩니다.
+          다시 분석하면 추천 절차·변제 계획이 갱신되지만, 진행 상태·절차가 1단계로 초기화되고 AI
+          상담 채팅 이력이 삭제되며 되돌릴 수 없습니다. 값만 저장하면 채무 구성만 반영됩니다.
         </p>
 
         <div className="w-full h-px border-t border-neutral-30 shrink-0" />

--- a/src/components/debt-relief/result/DiagnosisCustomerInfoModal.tsx
+++ b/src/components/debt-relief/result/DiagnosisCustomerInfoModal.tsx
@@ -80,12 +80,6 @@ function formatManwon(value: number | null | undefined): string {
   return `${value.toLocaleString("ko-KR")}만원`;
 }
 
-function formatSignedManwon(value: number | null | undefined): string {
-  if (value == null || Number.isNaN(value)) return "-";
-  const sign = value > 0 ? "+" : value < 0 ? "-" : "";
-  return `${sign}${Math.abs(value).toLocaleString("ko-KR")}만원`;
-}
-
 /** 법정 생계비처럼 월소득에서 차감되는 항목 표시용 — Figma가 "-" 부호를 붙여 보여준다. */
 function formatDeductedManwon(value: number | null | undefined): string {
   if (value == null || Number.isNaN(value)) return "-";
@@ -323,7 +317,7 @@ function buildSections(input: AnalysisInputData) {
     },
     {
       label: "월 가용소득",
-      value: formatSignedManwon(input.disposableIncome),
+      value: formatManwon(input.disposableIncome),
       emphasize: true,
     },
   ];

--- a/src/components/debt-relief/result/SectionDebtStatus.tsx
+++ b/src/components/debt-relief/result/SectionDebtStatus.tsx
@@ -51,7 +51,6 @@ export default function SectionDebtStatus({
   onDebtApplied?: () => void | Promise<void>;
 }) {
   const debt: DebtStatusSummary = detail.debtStatus;
-  const availableSign = debt.monthlyAvailableIncomeManwon >= 0 ? "+" : "";
   // 상세입력 모드 건에만 이자 포함 총채무가 내려온다 — 간편모드면 "총 상환 예정" 칸 자체를 숨긴다.
   const hasInterest = debt.totalDebtWithInterestManwon != null;
   const [debtDetailOpen, setDebtDetailOpen] = useState(false);
@@ -106,7 +105,7 @@ export default function SectionDebtStatus({
           />
           <Metric
             label="월 가용 소득"
-            value={`${availableSign}${debt.monthlyAvailableIncomeManwon.toLocaleString("ko-KR")}`}
+            value={debt.monthlyAvailableIncomeManwon.toLocaleString("ko-KR")}
             unit="만원"
           />
         </div>


### PR DESCRIPTION
- DebtApplyChoiceModal의 "다시 분석" 버튼이 진행상태 초기화·AI 채팅 이력 삭제를 명시하지 않아 경고 수위가 약했던 문제를 수정 폼(DiagnosisFormContent)의 확인 모달과 동일한 문구로 보강
- 채무 현황 카드/고객정보 모달의 월 가용소득 양수 표시에서 불필요한 "+" 기호 제거 (목록 테이블의 마이너스 강조색은 여러 건 훑어볼 때 식별용으로 의도된 디자인이라 유지)
- Step2Assets의 "부동산 보유 여부"가 미확인 상태에서도 "없음"이 이미 선택된 것처럼 보여 첫 클릭에 해제→재클릭해야 체크되던 문제 수정