### PR TITLE
fix: 공유 뱃지 테두리 색상 통일, 분석 폼 좌측 패널 월 가용소득 + 기호 제거

### DIFF
--- a/src/components/debt-relief/form/FormFinancialSummary.tsx
+++ b/src/components/debt-relief/form/FormFinancialSummary.tsx
@@ -1,8 +1,7 @@
 import type { DiagnosisDerivedValues } from "@/types/debtRelief";
 
-function formatManwon(value: number, withSign = false): string {
-  const sign = withSign && value >= 0 ? "+" : "";
-  return `${sign}${value.toLocaleString("ko-KR")}`;
+function formatManwon(value: number): string {
+  return value.toLocaleString("ko-KR");
 }
 
 function SummaryRow({
@@ -52,7 +51,7 @@ export default function FormFinancialSummary({
       />
       <SummaryRow
         label="월 가용소득"
-        value={formatManwon(derived.monthlyAvailableIncomeManwon, true)}
+        value={formatManwon(derived.monthlyAvailableIncomeManwon)}
         unit="만원"
         highlight={derived.monthlyAvailableIncomeManwon < 0 ? "danger" : "default"}
       />

--- a/src/components/debt-relief/hub/DiagnosisMobileCardList.tsx
+++ b/src/components/debt-relief/hub/DiagnosisMobileCardList.tsx
@@ -134,7 +134,7 @@ export default function DiagnosisMobileCardList({
               </div>
               {showShareButton &&
                 (item.isShared ? (
-                  <span className="inline-flex h-[22px] max-w-[160px] items-center justify-center rounded-[24px] border border-neutral-20 px-2 py-0.5">
+                  <span className="inline-flex h-[22px] max-w-[160px] items-center justify-center rounded-[24px] border border-neutral-30 px-2 py-0.5">
                     <span className="truncate text-[12px] font-semibold leading-[17px] text-neutral-60">
                       {item.lawyerProjectName || "공유된 프로젝트"}
                     </span>

--- a/src/components/debt-relief/hub/DiagnosisTable.tsx
+++ b/src/components/debt-relief/hub/DiagnosisTable.tsx
@@ -279,7 +279,7 @@ export default function DiagnosisTable({
                       <div className="flex h-full items-center">
                         {item.isShared ? (
                           <span
-                            className="inline-flex h-[22px] max-w-[160px] items-center justify-center rounded-[24px] border border-neutral-20 px-2 py-0.5"
+                            className="inline-flex h-[22px] max-w-[160px] items-center justify-center rounded-[24px] border border-neutral-30 px-2 py-0.5"
                             title={item.lawyerProjectName?.trim() || "공유됨"}
                             onClick={(e) => e.stopPropagation()}
                           >

--- a/src/components/debt-relief/result/ResultHeader.tsx
+++ b/src/components/debt-relief/result/ResultHeader.tsx
@@ -698,7 +698,7 @@ export default function ResultHeader({
 
           <div className="flex items-center gap-2 shrink-0">
             {detail.isShared ? (
-              <span className="inline-flex h-[22px] items-center justify-center rounded-[24px] border border-neutral-20 px-2 py-0.5 whitespace-nowrap">
+              <span className="inline-flex h-[22px] items-center justify-center rounded-[24px] border border-neutral-30 px-2 py-0.5 whitespace-nowrap">
                 <span className="text-[12px] font-semibold leading-[17px] text-neutral-60">
                   {shareLabel}
                 </span>


### PR DESCRIPTION
- 공유 상태 뱃지(목록 테이블/모바일 카드/결과화면 헤더)의 테두리를 Figma 개편안 색상 (#E2E2E2, neutral-30)에 맞게 통일. 기존 neutral-20은 다크모드에서 배경과 거의 구분되지 않았음
- 분석 신규/수정 폼 좌측 요약 패널의 월 가용소득도 양수일 때 "+" 기호를 표시하지 않도록 통일(다른 화면들과 동일 규칙 적용)