### PR TITLE
fix: 고객 상세 모달의 카테고리 드롭다운 클릭 시 모달 전체가 닫히는 버그 수정

### DIFF
--- a/src/components/customers/detail/CategoryDropdownPortal.tsx
+++ b/src/components/customers/detail/CategoryDropdownPortal.tsx
@@ -98,6 +98,7 @@ export default function CategoryDropdownPortal({
   return createPortal(
     <div
       ref={dropdownRef}
+      data-anchored-panel
       className="fixed z-[220] rounded-[5px] border border-[#E2E2E2] bg-card p-0 shadow-[0_8px_12px_rgba(9,30,66,0.1)] dark:border-neutral-30 dark:bg-neutral-10"
       style={{
         top: position.top,


### PR DESCRIPTION
CategoryDropdownPortal이 document.body에 별도 포털링되면서
data-anchored-panel 마킹이 빠져 있었다. BaseModal 오버레이의
바깥 클릭 판정 로직이 이 포털 콘텐츠를 "모달 바깥 클릭"으로 오인해
드롭다운 안에서 아무 항목을 눌러도 감싸고 있는 고객 상세 모달까지
함께 닫혔다. DatePicker/MonthPicker/TimePicker/ColorPalettePopover와 동일하게 data-anchored-panel 속성을 붙여 BaseModal의 예외 처리
대상에 포함시켰다.