### PR TITLE
fix: 진단서 신규/수정 폼 데스크톱 레이아웃 전환 기준을 md에서 lg로 변경

### DIFF
--- a/src/components/debt-relief/form/AnalysisDebtSelectionModal.tsx
+++ b/src/components/debt-relief/form/AnalysisDebtSelectionModal.tsx
@@ -41,37 +41,37 @@ export default function AnalysisDebtSelectionModal({ open, debts, onClose, onCon
     <BaseModal
       onClose={onClose}
       overlayClassName="bg-black/50 dark:bg-[#000000CC]"
-      containerClassName="w-[calc(100vw-2rem)] max-w-[360px] overflow-hidden rounded-[14px] bg-card shadow-[0_13px_61px_rgba(169,169,169,0.366)] drop-shadow-[0_8px_12px_rgba(9,30,66,0.1)] md:w-[776px] md:max-w-[776px]"
+      containerClassName="w-[calc(100vw-2rem)] max-w-[360px] overflow-hidden rounded-[14px] bg-card shadow-[0_13px_61px_rgba(169,169,169,0.366)] drop-shadow-[0_8px_12px_rgba(9,30,66,0.1)] lg:w-[776px] lg:max-w-[776px]"
       ariaLabel="채무 현황 선택"
       disableAutoContainerSizing
     >
-      <div className="relative px-6 pb-4 pt-6 md:flex md:min-h-[74px] md:items-center md:px-7 md:py-0 md:pr-16">
-        <h2 className="shrink-0 text-[16px] font-semibold leading-[19px] text-foreground md:text-[18px] md:leading-[21px]">채무 현황 선택</h2>
-        <span className="mx-4 hidden h-4 w-px shrink-0 bg-neutral-60 md:block" aria-hidden />
-        <p className="mt-2 pr-8 text-[13px] font-medium leading-5 text-neutral-60 md:mt-0 md:min-w-0 md:flex-1 md:truncate md:pr-0 md:text-[16px]">체크를 해제하면 채무내역은 남아있지만 분석 대상에서 제외됩니다.</p>
-        <button type="button" onClick={onClose} aria-label="닫기" className="absolute right-6 top-6 grid h-6 w-6 cursor-pointer place-items-center text-neutral-50 hover:text-neutral-70 md:right-7 md:top-1/2 md:-translate-y-1/2"><CloseIcon /></button>
+      <div className="relative px-6 pb-4 pt-6 lg:flex lg:min-h-[74px] lg:items-center lg:px-7 lg:py-0 lg:pr-16">
+        <h2 className="shrink-0 text-[16px] font-semibold leading-[19px] text-foreground lg:text-[18px] lg:leading-[21px]">채무 현황 선택</h2>
+        <span className="mx-4 hidden h-4 w-px shrink-0 bg-neutral-60 lg:block" aria-hidden />
+        <p className="mt-2 pr-8 text-[13px] font-medium leading-5 text-neutral-60 lg:mt-0 lg:min-w-0 lg:flex-1 lg:truncate lg:pr-0 lg:text-[16px]">체크를 해제하면 채무내역은 남아있지만 분석 대상에서 제외됩니다.</p>
+        <button type="button" onClick={onClose} aria-label="닫기" className="absolute right-6 top-6 grid h-6 w-6 cursor-pointer place-items-center text-neutral-50 hover:text-neutral-70 lg:right-7 lg:top-1/2 lg:-translate-y-1/2"><CloseIcon /></button>
       </div>
 
-      <div className="max-h-[calc(100vh-220px)] overflow-y-auto px-6 pb-7 md:max-h-[376px] md:px-7 md:pb-[30px]">
-        <div className="flex flex-col gap-4 md:gap-5">
+      <div className="max-h-[calc(100vh-220px)] overflow-y-auto px-6 pb-7 lg:max-h-[376px] lg:px-7 lg:pb-[30px]">
+        <div className="flex flex-col gap-4 lg:gap-5">
           {debts.map((debt) => {
             const typeLabel = debtTypeLabels.get(debt.debtType) ?? "채무";
             const creditorLabel = debt.creditorName.trim() || typeLabel;
             return (
-              <label key={debt.id} className="flex h-16 cursor-pointer items-center rounded-[12px] bg-neutral-10 px-5 md:h-[71px] md:px-6">
+              <label key={debt.id} className="flex h-16 cursor-pointer items-center rounded-[12px] bg-neutral-10 px-5 lg:h-[71px] lg:px-6">
                 <Checkbox checked={selectedDebtIdSet.has(debt.id)} onChange={(checked) => toggleDebt(debt.id, checked)} size={24} className="shrink-0" ariaLabel={`${creditorLabel} 선택`} />
-                <span className="ml-3 min-w-0 flex-1 md:ml-[17px]">
-                  <span className="block truncate text-[14px] font-semibold leading-[17px] tracking-[0.2px] text-foreground md:text-[16px] md:leading-[19px]">{creditorLabel} ({typeLabel})</span>
+                <span className="ml-3 min-w-0 flex-1 lg:ml-[17px]">
+                  <span className="block truncate text-[14px] font-semibold leading-[17px] tracking-[0.2px] text-foreground lg:text-[16px] lg:leading-[19px]">{creditorLabel} ({typeLabel})</span>
                   <span className="mt-1 block text-[14px] font-medium leading-[17px] tracking-[0.2px] text-neutral-60">{isDebtCollateralLoan(debt) ? "담보부" : "무담보"}<span className="ml-4">{debt.overdueMonths === 0 ? "연체 없음" : `연체 ${debt.overdueMonths}개월`}</span></span>
                 </span>
-                <span className="ml-2 shrink-0 whitespace-nowrap text-right text-[14px] font-bold leading-[17px] tracking-[0.2px] text-foreground md:ml-4 md:text-[16px] md:leading-[19px]">{formatWon(debt.currentBalanceWon)}</span>
+                <span className="ml-2 shrink-0 whitespace-nowrap text-right text-[14px] font-bold leading-[17px] tracking-[0.2px] text-foreground lg:ml-4 lg:text-[16px] lg:leading-[19px]">{formatWon(debt.currentBalanceWon)}</span>
               </label>
             );
           })}
         </div>
       </div>
 
-      <div className="flex h-[60px] items-center justify-end gap-3 border-t border-neutral-30 px-6 md:h-[58px] md:px-7">
+      <div className="flex h-[60px] items-center justify-end gap-3 border-t border-neutral-30 px-6 lg:h-[58px] lg:px-7">
         <button type="button" onClick={onClose} className="h-[34px] cursor-pointer rounded-[5px] border border-neutral-30 px-3 text-[14px] font-semibold tracking-[-0.02em] text-foreground hover:bg-neutral-10">닫기</button>
         <button type="button" disabled={selectedDebtIds.length === 0} onClick={() => onConfirm(selectedDebtIds)} className="inline-flex h-[34px] cursor-pointer items-center gap-2 rounded-[5px] border border-primary-60 bg-card px-3 text-[14px] font-semibold tracking-[-0.02em] text-foreground drop-shadow-[2px_2px_5px_#D6FAE8] hover:bg-primary-10 disabled:cursor-not-allowed disabled:opacity-40"><AnalyzeSparkleIcon />분석하기</button>
       </div>

--- a/src/components/debt-relief/form/DebtHistoryCard.tsx
+++ b/src/components/debt-relief/form/DebtHistoryCard.tsx
@@ -25,22 +25,29 @@ export type DebtHistoryCardProps = {
   showDebtItemFieldErrors?: boolean;
   overLimitFields?: OverLimitDebtField[];
   scrollFadeColorClassName?: string;
+  /** 데스크톱형 카드 레이아웃 전환 기준. 신규/수정 폼은 desktop, 기존 재사용 화면은 tablet. */
+  desktopLayoutBreakpoint?: "tablet" | "desktop";
 };
 
-export default function DebtHistoryCard({ form, update, disabled = false, areaBackgroundClassName = "bg-neutral-10", showDebtItemFieldErrors = false, scrollFadeColorClassName }: DebtHistoryCardProps) {
+export default function DebtHistoryCard({ form, update, disabled = false, areaBackgroundClassName = "bg-neutral-10", showDebtItemFieldErrors = false, scrollFadeColorClassName, desktopLayoutBreakpoint = "tablet" }: DebtHistoryCardProps) {
   const handleModeChange = (mode: DebtDisplayMode) => {
     if (disabled) return;
     update("debtInputMode", mode);
     if (form.debts.length === 0) update("debts", [createEmptyDebtItem(crypto.randomUUID())]);
   };
 
+  const desktopHeaderClassName = desktopLayoutBreakpoint === "desktop"
+    ? "lg:flex-row lg:h-[70px] lg:items-center lg:px-6"
+    : "md:flex-row md:h-[70px] md:items-center md:px-6";
+  const desktopBodyPaddingClassName = desktopLayoutBreakpoint === "desktop" ? "lg:px-6" : "md:px-6";
+
   return <div data-debt-history-card className="min-w-0 overflow-hidden rounded-[14px] border border-neutral-30">
-    <div data-debt-history-header className="flex flex-col md:flex-row md:h-[70px] items-stretch md:items-center justify-between gap-3 bg-neutral-10 px-5 py-4 md:px-6">
+    <div data-debt-history-header className={`flex flex-col items-stretch justify-between gap-3 bg-neutral-10 px-5 py-4 ${desktopHeaderClassName}`}>
       <div><h3 className="text-[16px] font-bold text-foreground">채무내역</h3><p className="mt-1.5 text-[13px] text-neutral-60">{SUBTITLE[form.debtInputMode]}</p></div>
       <DebtModeToggle value={form.debtInputMode} onChange={handleModeChange} disabled={disabled} />
     </div>
-    <div className={`flex flex-col gap-5 px-5 md:px-6 py-5 ${disabled ? "pointer-events-none opacity-80" : ""}`}>
-      <DebtItemsTable debts={form.debts} assets={form.assets} mode={form.debtInputMode} onChange={(debts) => update("debts", debts)} sumCardBackgroundClassName={areaBackgroundClassName} showFieldErrors={showDebtItemFieldErrors} lockedDebtIds={form.assetOriginDebtIds} scrollFadeColorClassName={scrollFadeColorClassName} />
+    <div className={`flex flex-col gap-5 px-5 py-5 ${desktopBodyPaddingClassName} ${disabled ? "pointer-events-none opacity-80" : ""}`}>
+      <DebtItemsTable debts={form.debts} assets={form.assets} mode={form.debtInputMode} onChange={(debts) => update("debts", debts)} sumCardBackgroundClassName={areaBackgroundClassName} showFieldErrors={showDebtItemFieldErrors} lockedDebtIds={form.assetOriginDebtIds} scrollFadeColorClassName={scrollFadeColorClassName} desktopLayoutBreakpoint={desktopLayoutBreakpoint} />
     </div>
   </div>;
 }

--- a/src/components/debt-relief/form/DebtItemsTable.tsx
+++ b/src/components/debt-relief/form/DebtItemsTable.tsx
@@ -41,6 +41,8 @@ type Props = {
   lockedDebtIds?: readonly string[];
   /** 넘김 버튼 뒤 그라데이션이 맞닿는 컨테이너 색. 호출 화면의 실제 배경색에 맞춰 오버라이드한다. */
   scrollFadeColorClassName?: string;
+  /** 합계 카드가 3열로 전환되는 기준. 결과 상세 모달은 기존 tablet, 신규/수정 폼은 desktop을 사용한다. */
+  desktopLayoutBreakpoint?: "tablet" | "desktop";
 };
 
 // "YYYY-MM-DD" ↔ 로컬 Date. new Date(isoString)은 UTC로 해석돼 시간대에 따라 하루 밀릴 수
@@ -289,6 +291,7 @@ export default function DebtItemsTable({
   assetCollateralOnly = false,
   lockedDebtIds = [],
   scrollFadeColorClassName = "[--debt-scroll-fade:#FFFFFF] dark:[--debt-scroll-fade:#111111]",
+  desktopLayoutBreakpoint = "tablet",
 }: Props) {
   const { containerRef, dragScrollHandlers } = useHorizontalDragScroll<HTMLDivElement>();
   const [horizontalScrollState, setHorizontalScrollState] = useState({
@@ -339,7 +342,7 @@ export default function DebtItemsTable({
     <>
       <div
         aria-hidden
-        className={`pointer-events-none absolute top-1/2 z-10 h-[146px] w-[90px] -translate-y-1/2 ${
+        className={`pointer-events-none absolute inset-y-0 z-10 w-[90px] ${
           horizontalScrollState.atEnd
             ? "left-0 bg-[linear-gradient(270deg,transparent_0%,var(--debt-scroll-fade)_80%)]"
             : "right-0 bg-[linear-gradient(90deg,transparent_0%,var(--debt-scroll-fade)_80%)]"
@@ -390,8 +393,10 @@ export default function DebtItemsTable({
   const totals = sumDebtItems(debts);
   const collateralTotals = sumDebtItems(debts.filter(isDebtCollateralLoan));
   const unsecuredTotals = sumDebtItems(debts.filter((debt) => !isDebtCollateralLoan(debt)));
+  const summaryGridColumnsClassName =
+    desktopLayoutBreakpoint === "desktop" ? "lg:grid-cols-3" : "md:grid-cols-3";
   const summaryCards = showSummaryCards ? (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-3 p-3 border-t border-neutral-30">
+    <div className={`grid grid-cols-1 ${summaryGridColumnsClassName} gap-3 p-3 border-t border-neutral-30`}>
       <DebtSumCard label="담보대출 합산" sums={collateralTotals} backgroundClassName={sumCardBackgroundClassName} />
       <DebtSumCard label="무담보대출 합산" sums={unsecuredTotals} backgroundClassName={sumCardBackgroundClassName} />
       <DebtSumCard label="총 합산" sums={totals} highlight />
@@ -402,7 +407,7 @@ export default function DebtItemsTable({
     const assetColumnWidths = [180, 220, 150, 220, 48];
     const assetTableWidth = assetColumnWidths.reduce((sum, width) => sum + width, 0);
     return (
-      <div data-debt-items-table className="rounded-t-[10px] border-t border-neutral-30 overflow-hidden">
+      <div data-debt-items-table className="rounded-t-[10px] overflow-hidden">
         <div className="relative">
           <div className="table-horizontal-scroll overflow-x-auto" ref={containerRef} {...dragScrollHandlers} onScroll={updateHorizontalScrollState}>
             <table className="border-collapse table-fixed" style={{ width: assetTableWidth, minWidth: "100%" }} aria-label="자산 담보대출 내역">
@@ -434,7 +439,7 @@ export default function DebtItemsTable({
     const simpleColumnWidths = [150, 100, 200, 140, 210, 48];
     const simpleTableWidth = simpleColumnWidths.reduce((sum, width) => sum + width, 0);
     return (
-      <div data-debt-items-table className="rounded-t-[10px] border-t border-neutral-30 overflow-hidden">
+      <div data-debt-items-table className="rounded-t-[10px] overflow-hidden">
         <div className="relative">
           <div className="table-horizontal-scroll overflow-x-auto" ref={containerRef} {...dragScrollHandlers} onScroll={updateHorizontalScrollState}>
             <table className="border-collapse table-fixed" style={{ width: simpleTableWidth, minWidth: "100%" }} aria-label="채무 간편 내역">
@@ -497,7 +502,7 @@ export default function DebtItemsTable({
   const detailedTableWidth = detailedColumnWidths.reduce((sum, width) => sum + width, 0);
 
   return (
-    <div data-debt-items-table className="rounded-t-[10px] border-t border-neutral-30 overflow-hidden">
+    <div data-debt-items-table className="rounded-t-[10px] overflow-hidden">
       <div className="relative">
         <div className="table-horizontal-scroll overflow-x-auto" ref={containerRef} {...dragScrollHandlers} onScroll={updateHorizontalScrollState}>
           <table

--- a/src/components/debt-relief/form/DiagnosisFormContent.tsx
+++ b/src/components/debt-relief/form/DiagnosisFormContent.tsx
@@ -688,7 +688,7 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
         onCustomerUnlink={handleCustomerUnlink}
       />
 
-      <div className="mx-auto max-w-[1324px] w-full px-0 md:px-6 lg:px-0 md:pt-9 pb-[90px] md:pb-12 flex flex-col md:flex-row gap-5 md:gap-[30px] items-start">
+      <div className="mx-auto max-w-[1324px] w-full px-0 lg:pt-9 pb-[90px] lg:pb-12 flex flex-col lg:flex-row gap-5 lg:gap-[30px] items-start">
         <FormSidebar
           form={form}
           derived={derived}
@@ -702,7 +702,7 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
           onCustomerUnlink={handleCustomerUnlink}
         />
 
-        <section className="relative flex-1 w-full min-w-0 surface md:rounded-[14px] shadow-none md:shadow-[0_13px_61px_rgba(169,169,169,0.12)] dark:shadow-none flex flex-col min-h-0 md:min-h-[780px]">
+        <section className="relative flex-1 w-full min-w-0 surface lg:rounded-[14px] shadow-none lg:shadow-[0_13px_61px_rgba(169,169,169,0.12)] dark:shadow-none flex flex-col min-h-0 lg:min-h-[780px]">
           {/* Figma 모바일: X는 폼 카드 우측 상단 — stroke는 foreground 토큰(라이트=#000급 / 다크 반전).
               "기타사항" 스텝은 Step5Others의 첫 실제 섹션인 "새출발기금" 제목 행에 X를 배치한다. */}
           {step.key !== "others" && (
@@ -710,7 +710,7 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
               type="button"
               onClick={handleClose}
               aria-label="닫기"
-              className="md:hidden absolute top-[8px] right-6 z-10 cursor-pointer w-6 h-6 grid place-items-center text-foreground hover:opacity-70"
+              className="lg:hidden absolute top-[8px] right-6 z-10 cursor-pointer w-6 h-6 grid place-items-center text-foreground hover:opacity-70"
             >
               <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden>
                 <path
@@ -727,7 +727,7 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
           {/* 헤더 — 모바일에서는 MobileFormSummaryDrawer가 대신하므로 숨김 */}
           {/* Figma: title 24/700, desc 18/500, gap 16, 패딩 28, 구분선은 카드 풀폭 */}
           {/* 좌측 이전 화살표는 제거(탭 + 하단 이전/다음 버튼과 중복). X는 생성/수정 모두 동일 기능(handleClose)으로 노출 */}
-          <div className="hidden md:flex items-center justify-between gap-4 px-7 py-[26px]">
+          <div className="hidden lg:flex items-center justify-between gap-4 px-7 py-[26px]">
             <div className="flex items-center gap-4 min-w-0">
               <h2 className="text-[24px] font-bold leading-5 text-neutral-90 shrink-0">{step.title}</h2>
               <span className="w-px h-4 bg-neutral-60 shrink-0" />
@@ -750,15 +750,15 @@ export default function DiagnosisFormContent({ diagnosisId }: { diagnosisId?: st
               </svg>
             </button>
           </div>
-          <div role="separator" className="hidden md:block h-px bg-neutral-30 opacity-50" />
+          <div role="separator" className="hidden lg:block h-px bg-neutral-30 opacity-50" />
 
           {/* 본문 — Figma 모바일: 좌우 16, 상단에서 바로 필드 시작 */}
-          <div className="flex-1 min-w-0 px-6 md:px-7 pt-4 md:pt-8 pb-7">{renderStep()}</div>
+          <div className="flex-1 min-w-0 px-6 lg:px-7 pt-4 lg:pt-8 pb-7">{renderStep()}</div>
 
           {/* 푸터 — 데스크톱 전용, 모바일은 FormMobileActionBar(fixed)가 대신함.
               3열 flex: 좌측 스페이서 ↔ 중앙 이전/다음 ↔ 우측 분석하기 (좌우 flex-1로 중앙 정렬 유지) */}
-          <div role="separator" className="hidden md:block h-px bg-neutral-30 opacity-50" />
-          <div className="hidden md:flex items-center px-7 pt-[13px] pb-3">
+          <div role="separator" className="hidden lg:block h-px bg-neutral-30 opacity-50" />
+          <div className="hidden lg:flex items-center px-7 pt-[13px] pb-3">
             <div className="flex-1" aria-hidden />
             <div className="flex items-center gap-2">
               <FormStepNavButton direction="prev" disabled={isFirst} onClick={goBack} />

--- a/src/components/debt-relief/form/FormControls.tsx
+++ b/src/components/debt-relief/form/FormControls.tsx
@@ -4,7 +4,7 @@ import { PillButton } from "./PillSelect";
 /** 스텝 본문 섹션 제목 — 데스크톱만. 모바일은 상단 드로어 스텝명이 대신함 */
 export function FormSectionTitle({ children }: { children: ReactNode }) {
   return (
-    <h3 className="hidden md:block text-[16px] font-semibold tracking-[0.2px] text-foreground pb-3 border-b border-neutral-30">
+    <h3 className="hidden lg:block text-[16px] font-semibold tracking-[0.2px] text-foreground pb-3 border-b border-neutral-30">
       {children}
     </h3>
   );
@@ -170,7 +170,7 @@ export function ManwonQuickInput({
             onChange(digits ? parseInt(digits, 10) : null);
           }}
           placeholder={placeholder}
-          className={`${QUICK_INPUT_CLASS} w-[148px] md:w-[180px] text-right`}
+          className={`${QUICK_INPUT_CLASS} w-[148px] lg:w-[180px] text-right`}
           aria-label="금액(만원)"
         />
         <span className="shrink-0 text-[14px] font-medium tracking-[-0.02em] text-neutral-60">

--- a/src/components/debt-relief/form/FormMobileActionBar.tsx
+++ b/src/components/debt-relief/form/FormMobileActionBar.tsx
@@ -15,7 +15,7 @@ export default function FormMobileActionBar({
   onNext,
 }: Props) {
   return (
-    <div className="md:hidden fixed bottom-0 left-0 right-0 z-30 surface border-t border-neutral-20 px-6 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] flex items-center justify-center gap-2">
+    <div className="lg:hidden fixed bottom-0 left-0 right-0 z-30 surface border-t border-neutral-20 px-6 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] flex items-center justify-center gap-2">
       <FormStepNavButton direction="prev" disabled={isFirst} onClick={onBack} />
       <FormStepNavButton direction="next" disabled={isLast} onClick={onNext} />
     </div>

--- a/src/components/debt-relief/form/FormSidebar.tsx
+++ b/src/components/debt-relief/form/FormSidebar.tsx
@@ -41,7 +41,7 @@ export default function FormSidebar({
   onCustomerUnlink,
 }: Props) {
   return (
-    <aside className="hidden md:flex md:w-[286px] shrink-0 flex-col surface md:rounded-[14px] pt-4 pb-8 px-[28px] shadow-[0_13px_61px_rgba(169,169,169,0.12)] dark:shadow-none">
+    <aside className="hidden lg:flex lg:w-[286px] shrink-0 flex-col surface lg:rounded-[14px] pt-4 pb-8 px-[28px] shadow-[0_13px_61px_rgba(169,169,169,0.12)] dark:shadow-none">
       <FormCustomerSummary
         form={form}
         isCustomerConnected={isCustomerConnected}

--- a/src/components/debt-relief/form/FormToggle.tsx
+++ b/src/components/debt-relief/form/FormToggle.tsx
@@ -39,8 +39,8 @@ export function FormToggleRow({
 }) {
   return (
     <div
-      className={`flex items-center justify-between gap-5 min-h-[34px] w-full md:justify-start ${
-        wideGap ? "md:gap-[150px]" : ""
+      className={`flex items-center justify-between gap-5 min-h-[34px] w-full lg:justify-start ${
+        wideGap ? "lg:gap-[150px]" : ""
       }`}
     >
       <span className="min-w-0 text-[14px] font-medium leading-[17px] text-foreground">{label}</span>

--- a/src/components/debt-relief/form/MobileFormSummaryDrawer.tsx
+++ b/src/components/debt-relief/form/MobileFormSummaryDrawer.tsx
@@ -96,7 +96,7 @@ export default function MobileFormSummaryDrawer({
 
   return (
     <div
-      className={`md:hidden sticky top-[54px] z-30 surface flex flex-col ${
+      className={`lg:hidden sticky top-[54px] z-30 surface flex flex-col ${
         expanded ? DRAWER_MAX_H : ""
       }`}
     >

--- a/src/components/debt-relief/form/PillSelect.tsx
+++ b/src/components/debt-relief/form/PillSelect.tsx
@@ -18,10 +18,10 @@ export function PillButton({
     <button
       type="button"
       onClick={onClick}
-      className={`cursor-pointer inline-flex items-center justify-center box-border h-[31px] md:h-[34px] px-3 md:px-5 py-0 rounded-full text-[14px] font-medium leading-none transition-colors ${
+      className={`cursor-pointer inline-flex items-center justify-center box-border h-[31px] lg:h-[34px] px-3 lg:px-5 py-0 rounded-full text-[14px] font-medium leading-none transition-colors ${
         selected
           ? "border border-transparent bg-neutral-100 text-neutral-0"
-          : "border border-neutral-30 text-foreground/80 tracking-[-0.04em] md:tracking-normal hover:border-neutral-50"
+          : "border border-neutral-30 text-foreground/80 tracking-[-0.04em] lg:tracking-normal hover:border-neutral-50"
       }`}
     >
       {label}

--- a/src/components/debt-relief/form/Step1BasicInfo.tsx
+++ b/src/components/debt-relief/form/Step1BasicInfo.tsx
@@ -24,13 +24,13 @@ export default function Step1BasicInfo({ form, update }: Props) {
       <FormSectionTitle>고객 정보</FormSectionTitle>
 
       {/* Figma: 섹션 구분선 → 첫 필드 13px, 필드 간 20px */}
-      <div className="mt-0 md:mt-3 flex flex-col gap-5">
-        <div className="flex flex-col md:flex-row md:items-start gap-5 md:gap-7">
+      <div className="mt-0 lg:mt-3 flex flex-col gap-5">
+        <div className="flex flex-col lg:flex-row lg:items-start gap-5 lg:gap-7">
           <FormField
             label="고객명"
             required
             filled={Boolean(form.customerName.trim())}
-            className="flex-1 min-w-0 md:max-w-[230px]"
+            className="flex-1 min-w-0 lg:max-w-[230px]"
           >
             <TextInput
               value={form.customerName}

--- a/src/components/debt-relief/form/Step2Assets.tsx
+++ b/src/components/debt-relief/form/Step2Assets.tsx
@@ -40,7 +40,7 @@ export default function Step2Assets({ form, update }: Props) {
 
   return <div>
     <FormSectionTitle>고객 자산 현황</FormSectionTitle>
-    <div className="mt-4 md:mt-5 flex flex-wrap gap-2" role="list" aria-label="자산 종류 추가">
+    <div className="mt-4 lg:mt-5 flex flex-wrap gap-2" role="list" aria-label="자산 종류 추가">
       {ASSET_CATEGORY_OPTIONS.map((option) => {
         const hasAsset = form.assets.some((asset) => asset.category === option.value);
         return <button key={option.value} type="button" onClick={() => toggleAsset(option.value)} aria-pressed={hasAsset} aria-label={`${option.label} 자산 ${hasAsset ? "제거" : "추가"}`} className={`inline-flex h-[34px] cursor-pointer items-center gap-2 rounded-full border px-4 text-[14px] font-medium transition-colors ${hasAsset ? "border-neutral-90 bg-neutral-90 text-neutral-0" : "border-neutral-30 bg-card text-foreground hover:border-neutral-50"}`}><AssetIcon category={option.value} />{option.label}</button>;
@@ -64,20 +64,20 @@ export default function Step2Assets({ form, update }: Props) {
           update("assetOriginDebtIds", form.assetOriginDebtIds.filter((id) => !collateralDebts.some((debt) => debt.id === id)));
         };
         return <section key={asset.id} className="overflow-hidden rounded-[14px] border border-neutral-30 bg-card">
-          <div className="flex min-h-14 flex-wrap items-center gap-3 bg-neutral-10 px-5 py-2.5 md:px-6">
+          <div className="flex min-h-14 flex-wrap items-center gap-3 bg-neutral-10 px-5 py-2.5 lg:px-6">
             <div className="flex min-w-[130px] flex-1 items-center gap-2"><AssetIcon category={asset.category} /><strong className="text-[16px] font-semibold text-foreground">{category?.label}</strong></div>
             <div className="w-[152px] shrink-0"><ManwonInput value={asset.marketValue} onChange={(marketValue) => updateAsset(asset.id, { marketValue })} /></div>
             <button type="button" onClick={() => setAssets(form.assets.filter((item) => item.id !== asset.id))} aria-label={`${category?.label} 삭제`} className="grid h-8 w-8 cursor-pointer place-items-center text-neutral-50 hover:text-neutral-70"><RemoveIcon /></button>
           </div>
           <>
-            <div className="flex min-h-12 items-center justify-between gap-3 border-t border-neutral-30 px-5 md:px-6">
+            <div className="flex min-h-12 items-center justify-between gap-3 border-t border-neutral-30 px-5 lg:px-6">
               <span className="text-[14px] font-semibold text-neutral-90">담보대출</span>
               <div className="flex shrink-0 items-center gap-4">
                 {collateralDebts.length > 0 && <DebtModeToggle compact value={form.debtInputMode} onChange={(mode) => update("debtInputMode", mode)} disabled={false} />}
                 <FormToggle checked={collateralDebts.length > 0} onChange={setCollateralEnabled} ariaLabel={`${category?.label} 담보대출 여부`} />
               </div>
             </div>
-            {collateralDebts.length > 0 && <div className="border-t border-neutral-30 px-5 py-4 md:px-6">
+            {collateralDebts.length > 0 && <div className="border-t border-neutral-30 px-5 py-4 lg:px-6">
               <DebtItemsTable
                 debts={collateralDebts}
                 assets={[asset]}
@@ -86,14 +86,15 @@ export default function Step2Assets({ form, update }: Props) {
                 defaultCollateralAssetId={asset.id}
                 showSummaryCards={false}
                 assetCollateralOnly
+                desktopLayoutBreakpoint="desktop"
               />
             </div>}
           </>
-          <div className="flex flex-wrap items-center justify-between gap-2 border-t border-neutral-30 bg-neutral-10 px-5 py-3 text-[14px] md:px-6"><span className="font-medium text-neutral-60">시가 {asset.marketValue.toLocaleString("ko-KR")} - 담보 {Math.round(collateralValueWon / 10_000).toLocaleString("ko-KR")}</span><strong className="text-[16px] text-foreground">순 자산 {(asset.marketValue - Math.round(collateralValueWon / 10_000)).toLocaleString("ko-KR")}만원</strong></div>
+          <div className="flex flex-wrap items-center justify-between gap-2 border-t border-neutral-30 bg-neutral-10 px-5 py-3 text-[14px] lg:px-6"><span className="font-medium text-neutral-60">시가 {asset.marketValue.toLocaleString("ko-KR")} - 담보 {Math.round(collateralValueWon / 10_000).toLocaleString("ko-KR")}</span><strong className="text-[16px] text-foreground">순 자산 {(asset.marketValue - Math.round(collateralValueWon / 10_000)).toLocaleString("ko-KR")}만원</strong></div>
         </section>;
       })}
-      <div className="flex items-center justify-between gap-4 rounded-xl bg-neutral-10 px-5 py-4 md:px-6"><span className="text-[14px] font-medium text-neutral-60">등록된 자산 {form.assets.length}건</span><div className="flex items-baseline gap-1"><strong className="text-[20px] font-bold tracking-[-0.03em] text-foreground">{totalAssetValue.toLocaleString("ko-KR")}</strong><span className="text-[13px] font-semibold text-neutral-60">만원</span></div></div>
-      <div className="flex items-center justify-between gap-3 rounded-[14px] border border-neutral-30 px-5 py-4 md:px-6"><span className="text-[14px] font-semibold text-neutral-90">최근 2년 내 재산 처분 이력</span><FormToggle checked={form.hasRecentAssetDisposal} onChange={(checked) => update("hasRecentAssetDisposal", checked)} ariaLabel="최근 2년 내 재산 처분 이력 있음" /></div>
+      <div className="flex items-center justify-between gap-4 rounded-xl bg-neutral-10 px-5 py-4 lg:px-6"><span className="text-[14px] font-medium text-neutral-60">등록된 자산 {form.assets.length}건</span><div className="flex items-baseline gap-1"><strong className="text-[20px] font-bold tracking-[-0.03em] text-foreground">{totalAssetValue.toLocaleString("ko-KR")}</strong><span className="text-[13px] font-semibold text-neutral-60">만원</span></div></div>
+      <div className="flex items-center justify-between gap-3 rounded-[14px] border border-neutral-30 px-5 py-4 lg:px-6"><span className="text-[14px] font-semibold text-neutral-90">최근 2년 내 재산 처분 이력</span><FormToggle checked={form.hasRecentAssetDisposal} onChange={(checked) => update("hasRecentAssetDisposal", checked)} ariaLabel="최근 2년 내 재산 처분 이력 있음" /></div>
     </div>
   </div>;
 }

--- a/src/components/debt-relief/form/Step3Debts.tsx
+++ b/src/components/debt-relief/form/Step3Debts.tsx
@@ -41,13 +41,14 @@ export default function Step3Debts({
     // absolute로 떠 있는 X 버튼(top-[8px] h-6, 하단 32px)과 카드 상단 테두리가 겹쳐 보였다.
     // 다른 스텝은 첫 요소가 일반 텍스트/타이틀이라 겹치지 않아 문제없었음 — 전체 상단 여백을
     // 늘리는 대신 이 스텝에서만 살짝 밀어내 Figma의 "다른 스텝은 상단에서 바로 시작" 의도를 유지.
-    <div className="mt-6 flex flex-col gap-5 md:mt-0">
+    <div className="mt-6 flex flex-col gap-5 lg:mt-0">
       <DebtHistoryCard
         form={form}
         update={update}
         totalDebtManwon={derived.totalDebtManwon}
         showDebtItemFieldErrors={debtItemFieldsMissingChecked}
         overLimitFields={overLimitFields}
+        desktopLayoutBreakpoint="desktop"
       />
 
       {/* 카드 바깥 공통 영역 — 채무 종류별 잔액과 무관하게 입력 방식 상관없이 항상 필요한 항목.

--- a/src/components/debt-relief/form/Step4IncomeExpense.tsx
+++ b/src/components/debt-relief/form/Step4IncomeExpense.tsx
@@ -29,7 +29,7 @@ export default function Step4IncomeExpense({ form, update, derived }: Props) {
     <div>
       <FormSectionTitle>고객 소득/지출</FormSectionTitle>
 
-      <div className="mt-0 md:mt-3 flex flex-col gap-5">
+      <div className="mt-0 lg:mt-3 flex flex-col gap-5">
         {/* 2026-07-24 피드백: 기본정보(Step1)에서 이 스텝으로 이동 */}
         <FormField label="고용 형태" required filled={form.employmentType !== null}>
           <PillSelect

--- a/src/components/debt-relief/form/Step5Others.tsx
+++ b/src/components/debt-relief/form/Step5Others.tsx
@@ -30,14 +30,14 @@ const TEXTAREA_CLASS =
   "w-full h-[84px] px-3 py-2 rounded-[5px] border border-neutral-30 bg-card text-[14px] font-medium tracking-[-0.02em] text-foreground placeholder:text-neutral-60 focus:outline-none focus:border-neutral-50 resize-none";
 
 // FormSectionTitle(FormControls.tsx)은 "데스크톱만, 모바일은 상단 드로어 스텝명이 대신함"
-// 전제로 hidden md:block이다 — 이 스텝에 섹션이 "소송 및 채무조정 이력" 하나뿐일 때는 맞는
+// 전제로 hidden lg:block이다 — 이 스텝에 섹션이 "소송 및 채무조정 이력" 하나뿐일 때는 맞는
 // 전제였지만, 새출발기금 섹션이 추가되며 모바일에서 두 섹션의 경계가 안 보이게 됐다(바로
 // 다음 항목인 "이전 신청 이력 있음"↔"이전 개인회생/파산 신청 이력 있음"이 라벨까지 비슷해
 // 헷갈리기 쉬움). FormSectionTitle 자체(다른 스텝도 공유)는 그대로 두고, 이 스텝에서만
 // 모바일 전용 제목을 나란히 둔다.
 function MobileSectionTitle({ children, onClose }: { children: string; onClose?: () => void }) {
   return (
-    <div className="md:hidden flex items-center justify-between gap-3 border-b border-neutral-30 pb-3">
+    <div className="lg:hidden flex items-center justify-between gap-3 border-b border-neutral-30 pb-3">
       <h3 className="text-[16px] font-semibold tracking-[0.2px] text-foreground">
         {children}
       </h3>
@@ -107,7 +107,7 @@ export default function Step5Others({ form, update, onClose }: Props) {
           카드 우상단에 따로 떠 있던 닫기 버튼은 첫 섹션 제목 행에 배치한다. */}
       <MobileSectionTitle onClose={onClose}>새출발기금</MobileSectionTitle>
       <FormSectionTitle>새출발기금</FormSectionTitle>
-      <div className="mt-3 md:mt-6 flex flex-col gap-5">
+      <div className="mt-3 lg:mt-6 flex flex-col gap-5">
         <div className="flex flex-col gap-3">
           <p className="text-[14px] font-medium leading-[17px] text-neutral-60">
             &apos;20.4월 ~ &apos;25.6월 중 개인사업자·소상공인으로 사업 영위한 적 있음
@@ -182,7 +182,7 @@ export default function Step5Others({ form, update, onClose }: Props) {
         <FormSectionTitle>소송 및 채무조정 이력</FormSectionTitle>
       </div>
 
-      <div className="mt-3 md:mt-6 flex flex-col gap-6">
+      <div className="mt-3 lg:mt-6 flex flex-col gap-6">
         <ToggleDetailRow
           label="이전 개인회생 / 파산 신청 이력 있음"
           checked={form.hasPreviousApplication}


### PR DESCRIPTION
태블릿 폭(780~1080px)에서 모바일 요소와 데스크톱 요소가 동시에 보이거나
레이아웃이 어긋나던 문제 방지. DebtHistoryCard/DebtItemsTable은 다른 화면(DebtDetailModal 등)에서 기존 md 기준으로 재사용 중이라
desktopLayoutBreakpoint prop("tablet"/"desktop")으로 호출부별 분기.